### PR TITLE
Change deprecated key to silence complier warning

### DIFF
--- a/Airship/UI/Default/Subscription/Classes/Shared/UASubscriptionRootViewController.m
+++ b/Airship/UI/Default/Subscription/Classes/Shared/UASubscriptionRootViewController.m
@@ -191,7 +191,7 @@
     UALOG(@"Inventory update failed with error code %d and domain %@ and description: %@",error.code, error.domain, error.localizedDescription);
     if ([error.domain isEqualToString:UASubscriptionRequestErrorDomain]) {
         NSDictionary *userInfo = error.userInfo;
-        UALOG(@"URL Failed: %@", [userInfo objectForKey:NSErrorFailingURLStringKey]);
+        UALOG(@"URL Failed: %@", [userInfo objectForKey:NSURLErrorFailingURLStringErrorKey]);
     }
 }
 


### PR DESCRIPTION
- Change the deprecated NSErrorFailingURLStringKey to the not deprecated NSURLErrorFailingURLStringErrorKey.
