### PR TITLE
Fix crash associated with +[NSUserDefaults resetStandardUserDefaults] 

### DIFF
--- a/Airship/Library/PushLib/UAPush+Internal.h
+++ b/Airship/Library/PushLib/UAPush+Internal.h
@@ -68,7 +68,7 @@ extern UAPushJSONKey *const UAPushBadgeJSONKey;
 @property (nonatomic, assign) int registrationRetryDelay;
 
 /* Convenience pointer for getting to user defaults. */
-@property (nonatomic, assign) NSUserDefaults *standardUserDefaults;
+@property (nonatomic, readonly) NSUserDefaults *standardUserDefaults;
 @property (nonatomic, assign) UIRemoteNotificationType notificationTypes;
 
 /* Default push handler. */

--- a/Airship/Library/PushLib/UAPush.m
+++ b/Airship/Library/PushLib/UAPush.m
@@ -71,7 +71,6 @@ UA_VERSION_IMPLEMENTATION(UAPushVersion, UA_VERSION)
 @implementation UAPush 
 //Internal
 @synthesize registrationQueue;
-@synthesize standardUserDefaults;
 @synthesize defaultPushHandler;
 @synthesize registrationRetryDelay;
 @synthesize registrationPayloadCache;
@@ -124,7 +123,6 @@ static Class _uiClass;
         // released when replaced
         defaultPushHandler = [[NSClassFromString(PUSH_DELEGATE_CLASS) alloc] init];
         delegate = defaultPushHandler;
-        standardUserDefaults = [NSUserDefaults standardUserDefaults];
         [[NSNotificationCenter defaultCenter] addObserver:self 
                                                  selector:@selector(applicationDidBecomeActive) 
                                                      name:UIApplicationDidBecomeActiveNotification 
@@ -152,32 +150,32 @@ static Class _uiClass;
 #pragma mark Get/Set Methods
 
 - (BOOL)autobadgeEnabled {
-    return [standardUserDefaults boolForKey:UAPushBadgeSettingsKey];
+    return [self.standardUserDefaults boolForKey:UAPushBadgeSettingsKey];
 }
 
 - (void)setAutobadgeEnabled:(BOOL)autobadgeEnabled {
-    [standardUserDefaults setBool:autobadgeEnabled forKey:UAPushBadgeSettingsKey];
+    [self.standardUserDefaults setBool:autobadgeEnabled forKey:UAPushBadgeSettingsKey];
 }
 
 
 - (NSString *)alias {
-    return [standardUserDefaults stringForKey:UAPushAliasSettingsKey];
+    return [self.standardUserDefaults stringForKey:UAPushAliasSettingsKey];
 }
 
 - (void)setAlias:(NSString *)alias {
-    [standardUserDefaults setObject:alias forKey:UAPushAliasSettingsKey];
+    [self.standardUserDefaults setObject:alias forKey:UAPushAliasSettingsKey];
 }
 
 - (BOOL)canEditTagsFromDevice {
-   return [standardUserDefaults boolForKey:UAPushDeviceCanEditTagsKey];
+   return [self.standardUserDefaults boolForKey:UAPushDeviceCanEditTagsKey];
 }
 
 - (void)setCanEditTagsFromDevice:(BOOL)canEditTagsFromDevice {
-    [standardUserDefaults setBool:canEditTagsFromDevice forKey:UAPushDeviceCanEditTagsKey];
+    [self.standardUserDefaults setBool:canEditTagsFromDevice forKey:UAPushDeviceCanEditTagsKey];
 }
 
 - (NSArray *)tags {
-    NSArray *currentTags = [standardUserDefaults objectForKey:UAPushTagsSettingsKey];
+    NSArray *currentTags = [self.standardUserDefaults objectForKey:UAPushTagsSettingsKey];
     if (!currentTags) {
         currentTags = [NSArray array];
     }
@@ -185,7 +183,7 @@ static Class _uiClass;
 }
 
 - (void)setTags:(NSArray *)tags {
-    [standardUserDefaults setObject:tags forKey:UAPushTagsSettingsKey];
+    [self.standardUserDefaults setObject:tags forKey:UAPushTagsSettingsKey];
 }
 
 - (void)addTagsToCurrentDevice:(NSArray *)tags {
@@ -195,13 +193,13 @@ static Class _uiClass;
 }
 
 - (BOOL)pushEnabled {
-    return [standardUserDefaults boolForKey:UAPushEnabledSettingsKey];
+    return [self.standardUserDefaults boolForKey:UAPushEnabledSettingsKey];
 }
 
 - (void)setPushEnabled:(BOOL)enabled {
     //if the value has actually changed
     if (enabled != self.pushEnabled) {
-        [standardUserDefaults setBool:enabled forKey:UAPushEnabledSettingsKey];
+        [self.standardUserDefaults setBool:enabled forKey:UAPushEnabledSettingsKey];
         // Set the flag to indicate that an unRegistration (DELETE)call is needed. This
         // flag is checked on updateRegistration calls, and is used to prevent
         // API calls on every app init when the device is already unregistered.
@@ -211,7 +209,7 @@ static Class _uiClass;
             UALOG(@"registering for remote notifcations");
             [[UIApplication sharedApplication] registerForRemoteNotificationTypes:notificationTypes];
         } else {
-            [standardUserDefaults setBool:YES forKey:UAPushNeedsUnregistering];
+            [self.standardUserDefaults setBool:YES forKey:UAPushNeedsUnregistering];
             //note: we don't want to use the wrapper method here, because otherwise it will blow away the existing notificationTypes
             [[UIApplication sharedApplication] registerForRemoteNotificationTypes:UIRemoteNotificationTypeNone];
             [self updateRegistration];
@@ -220,19 +218,23 @@ static Class _uiClass;
 }
 
 - (NSDictionary *)quietTime {
-    return [standardUserDefaults dictionaryForKey:UAPushQuietTimeSettingsKey];
+    return [self.standardUserDefaults dictionaryForKey:UAPushQuietTimeSettingsKey];
 }
 
 - (void)setQuietTime:(NSMutableDictionary *)quietTime {
-    [standardUserDefaults setObject:quietTime forKey:UAPushQuietTimeSettingsKey];
+    [self.standardUserDefaults setObject:quietTime forKey:UAPushQuietTimeSettingsKey];
 }
 
 - (BOOL)quietTimeEnabled {
-    return [standardUserDefaults boolForKey:UAPushQuietTimeEnabledSettingsKey];
+    return [self.standardUserDefaults boolForKey:UAPushQuietTimeEnabledSettingsKey];
 }
 
 - (void)setQuietTimeEnabled:(BOOL)quietTimeEnabled {
-    [standardUserDefaults setBool:quietTimeEnabled forKey:UAPushQuietTimeEnabledSettingsKey];
+    [self.standardUserDefaults setBool:quietTimeEnabled forKey:UAPushQuietTimeEnabledSettingsKey];
+}
+
+- (NSUserDefaults *)standardUserDefaults {
+    return [NSUserDefaults standardUserDefaults];
 }
 
 - (NSString *)tz {
@@ -245,12 +247,12 @@ static Class _uiClass;
 }
 
 - (NSTimeZone *)timeZone {
-    NSString* timeZoneName = [standardUserDefaults stringForKey:UAPushTimeZoneSettingsKey];
+    NSString* timeZoneName = [self.standardUserDefaults stringForKey:UAPushTimeZoneSettingsKey];
     return [NSTimeZone timeZoneWithName:timeZoneName];
 }
 
 - (void)setTimeZone:(NSTimeZone *)timeZone {
-    [standardUserDefaults setObject:[timeZone name] forKey:UAPushTimeZoneSettingsKey];
+    [self.standardUserDefaults setObject:[timeZone name] forKey:UAPushTimeZoneSettingsKey];
 }
 
 - (NSTimeZone *)defaultTimeZoneForQuietTime {
@@ -413,9 +415,9 @@ static Class _uiClass;
 }
 
 - (void)removeTagsFromCurrentDevice:(NSArray *)tags {
-    NSMutableArray *mutableTags = [NSMutableArray arrayWithArray:[standardUserDefaults objectForKey:UAPushTagsSettingsKey]];
+    NSMutableArray *mutableTags = [NSMutableArray arrayWithArray:[self.standardUserDefaults objectForKey:UAPushTagsSettingsKey]];
     [mutableTags removeObjectsInArray:tags];
-    [standardUserDefaults setObject:mutableTags forKey:UAPushTagsSettingsKey];
+    [self.standardUserDefaults setObject:mutableTags forKey:UAPushTagsSettingsKey];
 }
 
 - (void)enableAutobadge:(BOOL)autobadge {
@@ -596,7 +598,7 @@ static Class _uiClass;
         return;
     }
     
-    [standardUserDefaults synchronize];
+    [self.standardUserDefaults synchronize];
     NSDictionary *currentRegistrationPayload = [self registrationPayload];;
     if ([registrationPayloadCache isEqualToDictionary:currentRegistrationPayload] 
         && self.pushEnabled == self.pushEnabledPayloadCache) {
@@ -625,7 +627,7 @@ static Class _uiClass;
             return;
         }
         // Don't unregister more than once
-        if ([standardUserDefaults boolForKey:UAPushNeedsUnregistering]) {
+        if ([self.standardUserDefaults boolForKey:UAPushNeedsUnregistering]) {
             UA_ASIHTTPRequest *deleteRequest = [self requestToDeleteDeviceToken];
             UALOG(@"Starting registration DELETE request (unregistering)");
             [deleteRequest startAsynchronous];
@@ -803,7 +805,7 @@ static Class _uiClass;
         // cache before setting isRegistering to NO
         [self cacheSuccessfulUserInfo:request.userInfo];
         // note that unregistration is no longer needed
-        [standardUserDefaults setBool:NO forKey:UAPushNeedsUnregistering];
+        [self.standardUserDefaults setBool:NO forKey:UAPushNeedsUnregistering];
         self.isRegistering = NO;
         if ([self cacheHasChangedComparedToUserInfo:request.userInfo]) {
             [self updateRegistration];


### PR DESCRIPTION
An app using libUAirship is liable to crash anytime after calling `+[NSUserDefaults resetStandardUserDefaults]`. This is because UAPush keeps a weak reference to an instance of NSUserDefaults obtained via `+[NSUserDefaults standardUserDefaults]`, which is released and possibly deallocated by `+[NSUserDefaults resetStandardUserDefaults]`.
