### PR TITLE
Fixes random crash

### DIFF
--- a/Airship/Common/UAUser.m
+++ b/Airship/Common/UAUser.m
@@ -115,7 +115,7 @@ static UAUser *_defaultUser;
 
 - (void)setDeviceToken:(NSString *)deviceToken {
     [_deviceToken autorelease];
-    _deviceToken = deviceToken;
+    _deviceToken = [deviceToken retain];
     NSString *lastDeviceToken = [[NSUserDefaults standardUserDefaults] stringForKey:kLastDeviceTokenKey];
     if (![_deviceToken isEqualToString:lastDeviceToken]) {
         _deviceTokenHasChanged = YES;


### PR DESCRIPTION
I've been experiencing a random crash, caused by UAUser class.

It's setter lacks a retain call. Whenever the deviceToken gets set again, the previous variable will get over-released, and the app is subject to a bad access crash.
