### PR TITLE
Fixing notify observers bug stemming from mutable set enumeration

### DIFF
--- a/Airship/Common/UAObservable.m
+++ b/Airship/Common/UAObservable.m
@@ -48,7 +48,7 @@
 -(void)notifyObservers:(SEL)selector {
     @synchronized(self) {
         NSSet* observer_copy = [self.observers copy];
-        for (id observer in self.observers) {
+        for (id observer in observer_copy) {
             if([observer respondsToSelector: selector]) {
                 [observer performSelector: selector];
             }


### PR DESCRIPTION
This fix handles the scenario when a view controller has been added as an observer to [UAInbox shared].messageList and a rich push notification is launching the app. Without this change, I was running into a "Collection <_NSSetM: ...> was mutated while being enumerated" exception in within this exact method call.
