### PR TITLE
Minor bug fixed: unreadCount property was not correctly updated

### DIFF
--- a/Airship/Inbox/UAInboxMessageList.m
+++ b/Airship/Inbox/UAInboxMessageList.m
@@ -237,6 +237,7 @@ static UAInboxMessageList *_messageList = nil;
         [self.client performBatchMarkAsReadForMessages:updateMessageArray onSuccess:^{
             for (UAInboxMessage *message in updateMessageArray) {
                 message.unread = NO;
+                self.unreadCount -= 1;
             }
             
             [[UAInboxDBManager shared] saveContext];


### PR DESCRIPTION
It is not the best solution but I think it solves a problem about updating correctly the unreadCount property. Messages have being set to unread = NO, and later when the success block is executed to update the unreadCount, message is already defined as unread=NO and the code doesn't execute unreadCount property decrement. Please, check this before because I'm not seeing all the scope of the context.
