### PR TITLE
Add CocoaPods specification.

### DIFF
--- a/UrbanAirship-iOS-SDK.podspec
+++ b/UrbanAirship-iOS-SDK.podspec
@@ -11,14 +11,28 @@ Pod::Spec.new do |s|
   
   # Airship ships both UA-prefixed ASI and SBJson, as well as un-prefixed
   # versions that are no longer used in the .xcodeproj.
-  s.source_files = 'Airship/**/*.{h,m,c}'
-  s.exclude_files = '**/asi-http-request/*', '**/json-framework/*', '**/google-toolbox-for-mac/*', '**/ZipFile-OC/*', '**/Reachability/*'
-  s.resources = 'Airship/**/*.{xib,jpg,png,bundle}'
   s.requires_arc = true
   s.libraries    = 'z', 'sqlite3.0'
   s.frameworks   = 'CFNetwork', 'CoreGraphics', 'Foundation', 'MobileCoreServices',
                    'Security', 'SystemConfiguration', 'UIKit', 'CoreTelephony', 'CoreLocation'
   
   s.platform = :ios, '5.1'
+
+  s.default_subspec = 'Core'
+
+  s.subspec 'Core' do |ss|
+    ss.source_files = 'Airship/{Common,Inbox,Push,External}/**.{h,m,c}', 'Airship/UI/Default/Push/Classes/Shared/UAPushNotificationHandler.h'
+    ss.ios.frameworks = 'CFNetwork', 'Foundation', 'MobileCoreServices',
+                   'Security', 'SystemConfiguration', 'CoreTelephony', 'CoreLocation'
+  end
+
+  s.subspec 'UI' do |ss|
+    ss.dependency 'UrbanAirship-iOS-SDK/Core'
+    ss.source_files = 'Airship/UI/**/*.{h,m,c}'
+    ss.resources = 'Airship/UI/**/*.{xib,jpg,png,bundle}'    
+    ss.ios.frameworks = 'CFNetwork', 'CoreGraphics', 'Foundation', 'MobileCoreServices',
+                   'Security', 'SystemConfiguration', 'UIKit', 'CoreTelephony', 'CoreLocation'
+  end
+
 end
 


### PR DESCRIPTION
A podspec has been in the Specs for some time now, managed by a third party. It would be awesome though if UA would do that instead.

The differences between the current entry in the Specs and this one is that I split the UI and Core. In my project I don't use the UI and I don't want to clog by build process and .app with useless code and XIBs. Using `pod 'UrbanAirship-iOS-SDK/Core'` now only puts the core (non /UI) in the project.

The podspec I added is for 3.0.4, because the project I have that uses this does not use 4.0.0 (yet), so I can't test that. It probably only needs an update to the version numbers.

You might want to rename the Podspec and the pod (find&replace of UrbanAirship-iOS-SDK) to something like UAUrbanAirship.
Please let me know, and I will change it :)
