### PR TITLE
mark background task as ended when OS calls the expiration handler

### DIFF
--- a/Airship/Push/UAPush.m
+++ b/Airship/Push/UAPush.m
@@ -713,6 +713,8 @@ BOOL deferChannelCreationOnForeground = false;
     if (self.registrationBackgroundTask == UIBackgroundTaskInvalid) {
         self.registrationBackgroundTask = [[UIApplication sharedApplication] beginBackgroundTaskWithExpirationHandler:^{
             [self.deviceRegistrar cancelAllRequests];
+            [[UIApplication sharedApplication] endBackgroundTask:self.registrationBackgroundTask];
+            self.registrationBackgroundTask = UIBackgroundTaskInvalid;
         }];
     }
 


### PR DESCRIPTION
According to documentation the expiration handler for -[UIApplication beginBackgroundTaskWithExpirationHandler:] must explicitly mark the task as ended via - [UIApplication endBackgroundTask:] when the OS decided to call the expiration handler.

There is a situation where a request for creating a channel (/api/channels/) fails and a retry is scheduled for after 300 sec thus the failure block is not called and the background task is never marked as ended. On iOS7 the maximum allowed time for running in background is ~3 min which means that the expiration handler is called before channel creation request retrial. Failure to mark the task as ended results in a crash.

<app> has active assertions beyond permitted time: 
    {(
        <BKProcessAssertion: 0x15531750> identifier: Called by <app>, from -[UAPush beginRegistrationBackgroundTask] process: <app>[183] permittedBackgroundDuration: 180.000000 reason: finishTask owner pid:183 preventSuspend  preventIdleSleep  preventSuspendOnSleep 
    )}
 Forcing crash report of <app>...

Reproducing the channel creation request failure is not always easy but when it happens this should fix the problem.
