### PR TITLE
Added missing quotes for path

### DIFF
--- a/scripts/generate_header_imports.sh
+++ b/scripts/generate_header_imports.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 
-SCRIPT_DIRECTORY=`dirname $0`
+SCRIPT_DIRECTORY=`dirname "$0"`
 ROOT_PATH=`dirname "${0}"`/../
 
 cd "${ROOT_PATH}/Airship"


### PR DESCRIPTION
`generate_header_imports.sh` doesn't work for paths with spaces due to missing quotes.
