### PR TITLE
Fixed wrong value passed to -[UITableView setSeparatorStyle:]

### DIFF
--- a/Airship/UI/Default/Inbox/Classes/Shared/UAInboxMessageListController.m
+++ b/Airship/UI/Default/Inbox/Classes/Shared/UAInboxMessageListController.m
@@ -269,7 +269,7 @@
     strongLoadingLabel.text = UAInboxLocalizedString(@"UA_Loading");
     // Set label color to white to contrast with dark beveled loading indicator background
     self.loadingLabel.textColor = [UIColor whiteColor];
-    [self.messageTable setSeparatorStyle:UITableViewCellSelectionStyleDefault];
+    [self.messageTable setSeparatorStyle:UITableViewCellSeparatorStyleSingleLine];
 
     UABeveledLoadingIndicator *strongLoadingIndicator = self.loadingIndicator;
     strongLoadingIndicator.alpha = 0.9;


### PR DESCRIPTION
A **cell selection style** was erroneously passed to `UITableView`'s **separatorStyle**.

This also caused a warning:

```
UAInboxMessageListController.m:272:42: Implicit conversion from enumeration type 'enum UITableViewCellSelectionStyle' to different enumeration type 'UITableViewCellSeparatorStyle' (aka 'enum UITableViewCellSeparatorStyle')
```
