### PR TITLE
Fix for #80 : The app is crashing if: -[UAEvent carrierName] is called.

### DIFF
--- a/Airship/Common/UAEvent.m
+++ b/Airship/Common/UAEvent.m
@@ -30,6 +30,8 @@
 #import "UA_Reachability.h"
 #import "UAPush.h"
 
+static CTTelephonyNetworkInfo *netInfo;
+
 @implementation UAEvent
 
 - (instancetype)init {
@@ -97,7 +99,12 @@
 }
 
 - (NSString *)carrierName {
-    CTTelephonyNetworkInfo *netInfo = [[CTTelephonyNetworkInfo alloc] init];
+    
+    static dispatch_once_t dispatchToken;
+    dispatch_once(&dispatchToken, ^{
+        netInfo = [[CTTelephonyNetworkInfo alloc] init];
+    });
+    
     return netInfo.subscriberCellularProvider.carrierName;
 }
 


### PR DESCRIPTION
https://github.com/urbanairship/ios-library/issues/80 The app is crashing if: -[UAEvent carrierName] is called. 
