### PR TITLE
fix UAAnalyticsDBManager getEvents: in iOS 64-bit can't work

### DIFF
--- a/Airship/Common/UAAnalyticsDBManager.h
+++ b/Airship/Common/UAAnalyticsDBManager.h
@@ -61,7 +61,7 @@
  * @param max Integer representing the sqlite query limit, max < 0 returns all the data
  * @return An array of analytics events from the DB
  */
-- (NSArray *)getEvents:(NSUInteger)max;
+- (NSArray *)getEvents:(UInt32)max;
 
 /**
  * Gets analytics events via sqlite query using event ID

--- a/Airship/Common/UAAnalyticsDBManager.m
+++ b/Airship/Common/UAAnalyticsDBManager.m
@@ -101,7 +101,7 @@
 }
 
 //If max<0, it will get all data.
-- (NSArray *)getEvents:(NSUInteger)max {
+- (NSArray *)getEvents:(UInt32)max {
     __block NSArray *result = nil;
     dispatch_sync(dbQueue, ^{
         result = [self.db executeQuery:@"SELECT * FROM analytics ORDER BY _id LIMIT ?", [NSNumber numberWithUnsignedInteger:max]];


### PR DESCRIPTION
this method in 32-bit work normal,but can't work in 64-bit, i think, this is sqlite bug.
for instance  [xxxx getEvents:-1];
