### PR TITLE
copy_header_imports.sh: Add missing quotes

### DIFF
--- a/AirshipKit/copy_header_imports.sh
+++ b/AirshipKit/copy_header_imports.sh
@@ -6,7 +6,7 @@ SOURCE_LIB_HEADER="${AIRSHIP_DIR}/AirshipLib.h"
 TARGET_LIB_HEADER="${FRAMEWORK_HEADERS_DIR}/AirshipLib.h"
 
 # If there's already an AirshipLib.h in the framework headers directory
-if [ -a ${FRAMEWORK_HEADERS_DIR}/AirshipLib.h ]; then
+if [ -a "${FRAMEWORK_HEADERS_DIR}/AirshipLib.h" ]; then
     # If the contents haven't changed, exit early
     if diff -q "${SOURCE_LIB_HEADER}" "${TARGET_LIB_HEADER}" > /dev/null; then
         exit 0


### PR DESCRIPTION
Fixes issue where the headers would be copied every time (and therefore triggering a recompile of files that include those headers) if the project's `BUILD_PRODUCTS_DIR` had a space.