### PR TITLE
Replace 'UAActionFetchResultNone' to 'UAActionFetchResultNoData'

### DIFF
--- a/Airship/Common/UAActionResult.h
+++ b/Airship/Common/UAActionResult.h
@@ -103,7 +103,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Creates a UAActionResult with the supplied value. The `fetchResult` and `error` properties
- * default to UAActionFetchResultNone and nil, respectively.
+ * default to UAActionFetchResultNoData and nil, respectively.
  *
  * @param value An id typed value object.
  * @return An instance of UAActionResult.
@@ -122,13 +122,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Creates an "empty" UAActionResult with the value, fetch result and error set to
- * nil, UAActionFetchResultNone, and nil, respectively.
+ * nil, UAActionFetchResultNoData, and nil, respectively.
  */
 + (instancetype)emptyResult;
 
 /**
  * Creates a UAActionResult with the value and fetch result set to
- * nil and UAActionFetchResultNone, respectively. The `error` property
+ * nil and UAActionFetchResultNoData, respectively. The `error` property
  * is set to the supplied argument.
  *
  * @param error An instance of NSError.

--- a/Airship/Common/UAAddTagsAction.h
+++ b/Airship/Common/UAAddTagsAction.h
@@ -39,7 +39,7 @@
  *
  * Error: nil
  *
- * Fetch result: UAActionFetchResultNone
+ * Fetch result: UAActionFetchResultNoData
  */
 @interface UAAddTagsAction : UAModifyTagsAction
 

--- a/Airship/Common/UAIncomingPushAction+Internal.h
+++ b/Airship/Common/UAIncomingPushAction+Internal.h
@@ -41,7 +41,7 @@
  * Error: nil
  *
  * Fetch result: Aggregate UAActionFetchResult from delegates when handling background pushes, otherwise
- * UAActionFetchResultNone
+ * UAActionFetchResultNoData
  */
 
 @interface UAIncomingPushAction : UAAction

--- a/Airship/Common/UAOpenExternalURLAction.h
+++ b/Airship/Common/UAOpenExternalURLAction.h
@@ -57,7 +57,7 @@ extern NSString * const UAOpenExternalURLActionErrorDomain;
  *
  * Error: `UAOpenExternalURLActionErrorCodeURLFailedToOpen` if the URL could not be opened
  *
- * Fetch result: UAActionFetchResultNone
+ * Fetch result: UAActionFetchResultNoData
  */
 @interface UAOpenExternalURLAction : UAAction
 

--- a/Airship/Common/UARemoveTagsAction.h
+++ b/Airship/Common/UARemoveTagsAction.h
@@ -39,7 +39,7 @@
  *
  * Error: nil
  *
- * Fetch result: UAActionFetchResultNone
+ * Fetch result: UAActionFetchResultNoData
  */
 @interface UARemoveTagsAction : UAModifyTagsAction
 


### PR DESCRIPTION
I noticed that the enum value of UAActionFetchResultNone doesn't exist in UAActionResult.h but is being referenced in header file documentation (comments) throughout the project.  I've updated all references to use UAActionFetchResultNoData instead.