### PR TITLE
Fix Inbox store's name

### DIFF
--- a/AirshipKit/AirshipKit/UAInboxDBManager.m
+++ b/AirshipKit/AirshipKit/UAInboxDBManager.m
@@ -186,7 +186,7 @@
     if (!_storeURL) {
         NSFileManager *fm = [NSFileManager defaultManager];
         NSURL *libraryDirectoryURL = [[fm URLsForDirectory:NSLibraryDirectory inDomains:NSUserDomainMask] lastObject];
-        NSURL *directoryURL = [libraryDirectoryURL URLByAppendingPathComponent:kUACoreDataStoreName];
+        NSURL *directoryURL = [libraryDirectoryURL URLByAppendingPathComponent:self.storeName];
 
         // Create the store directory if it doesnt exist
         if (![fm fileExistsAtPath:[directoryURL path]]) {


### PR DESCRIPTION
Inbox store's name depends on app key and because of that it cannot be used directly otherwise the store will be named `Inbox-%@.sqlite`.

> ⚠️ This will affect apps currently in production using Inbox feature.