### PR TITLE
Fixes issue with sqlite import

### DIFF
--- a/AirshipKit/AirshipKit/UASQLite.m
+++ b/AirshipKit/AirshipKit/UASQLite.m
@@ -3,7 +3,7 @@
 #import "UASQLite+Internal.h"
 #import "UAGlobal.h"
 
-#import "sqlite3.h"
+#import <sqlite3.h>
 
 @interface UASQLite ()
 @property(nonatomic, assign) sqlite3 *db;


### PR DESCRIPTION
There are some issues with using the UrbanAirship iOS SDK in the same app as some other modules that also use SQLite 3
(We ran into problems with GRDB https://github.com/groue/GRDB.swift)

These issues were easily solved by changing the SQLite import statement to search the global header paths