### PR TITLE
Fix and improvement to UAChannelCapture

### DIFF
--- a/AirshipKit/AirshipKit/ios/UAChannelCapture.m
+++ b/AirshipKit/AirshipKit/ios/UAChannelCapture.m
@@ -74,10 +74,15 @@ NSString *const UAChannelPlaceHolder = @"CHANNEL";
     if (!self.push.channelID) {
         return;
     }
-    
-    NSDate *date = [self.dataStore objectForKey:UAChannelCaptureEnabledKey];
-    
-    if ([self.push backgroundPushNotificationsEnabled] && [date compare:[NSDate date]] == NSOrderedAscending) {
+
+    if ([self.push backgroundPushNotificationsEnabled]) {
+        NSDate *enabledUntilDate = [self.dataStore objectForKey:UAChannelCaptureEnabledKey];
+        if (!enabledUntilDate || [enabledUntilDate compare:[NSDate date]] == NSOrderedAscending) {
+            return;
+        }
+    }
+
+    if ([[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){10, 0, 0}] && ![UIPasteboard generalPasteboard].hasStrings) {
         return;
     }
     


### PR DESCRIPTION
This PR:
Fixes a bug where channel capture would still occur even if background push notifications are enabled, as long as capture had never been enabled explicitly (missing nil check).
Add iOS 10+ only check to see if pasteboard even contains string data before accessing it.
