### PR TITLE
Fix warning when loading UAInbox managed object model

### DIFF
--- a/AirshipKit/AirshipResources/ios/UAInbox.xcdatamodeld/UAInbox.xcdatamodel/contents
+++ b/AirshipKit/AirshipResources/ios/UAInbox.xcdatamodeld/UAInbox.xcdatamodel/contents
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="12141" systemVersion="16E195" minimumToolsVersion="Automatic" sourceLanguage="Objective-C" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="12141" systemVersion="16F73" minimumToolsVersion="Automatic" sourceLanguage="Objective-C" userDefinedModelVersionIdentifier="">
     <entity name="UAInboxMessage" representedClassName="UAInboxMessageData" syncable="YES" codeGenerationType="class">
         <attribute name="deletedClient" optional="YES" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="extra" optional="YES" attributeType="Transformable" valueTransformerName="UAJSONValueTransformer" syncable="YES"/>
-        <attribute name="messageBodyURL" optional="YES" attributeType="Transformable" valueTransformerName="NSUnarchiveFromDataTransformerName" syncable="YES"/>
+        <attribute name="messageBodyURL" optional="YES" attributeType="Transformable" syncable="YES"/>
         <attribute name="messageExpiration" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="messageID" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="messageSent" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
-        <attribute name="messageURL" optional="YES" attributeType="Transformable" valueTransformerName="NSUnarchiveFromDataTransformerName" syncable="YES"/>
+        <attribute name="messageURL" optional="YES" attributeType="Transformable" syncable="YES"/>
         <attribute name="rawMessageObject" optional="YES" attributeType="Transformable" syncable="YES"/>
         <attribute name="title" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="unread" optional="YES" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>


### PR DESCRIPTION
Version 8.4.2 introduced the following warnings during takeoff:

CoreData: warning: no NSValueTransformer with class name 'NSUnarchiveFromDataTransformerName' was found for attribute 'messageBodyURL' on entity 'UAInboxMessage'
CoreData: warning: no NSValueTransformer with class name 'NSUnarchiveFromDataTransformerName' was found for attribute 'messageURL' on entity 'UAInboxMessage'

I fixed it by removing invalid value transformer names from the model file, as they are not required for most basic types. For example, rawMessageObject already didn't have a value transformer names since it's an NSDictionary.