### PR TITLE
Set default values for UAInboxMessage's boolean properties in the core data model

### DIFF
--- a/AirshipKit/AirshipResources/ios/UAInbox.xcdatamodeld/UAInbox.xcdatamodel/contents
+++ b/AirshipKit/AirshipResources/ios/UAInbox.xcdatamodeld/UAInbox.xcdatamodel/contents
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="12141" systemVersion="16F73" minimumToolsVersion="Automatic" sourceLanguage="Objective-C" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="12141" systemVersion="16G29" minimumToolsVersion="Automatic" sourceLanguage="Objective-C" userDefinedModelVersionIdentifier="">
     <entity name="UAInboxMessage" representedClassName="UAInboxMessageData" syncable="YES" codeGenerationType="class">
-        <attribute name="deletedClient" optional="YES" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="deletedClient" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="extra" optional="YES" attributeType="Transformable" valueTransformerName="UAJSONValueTransformer" syncable="YES"/>
         <attribute name="messageBodyURL" optional="YES" attributeType="Transformable" syncable="YES"/>
         <attribute name="messageExpiration" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
@@ -10,8 +10,8 @@
         <attribute name="messageURL" optional="YES" attributeType="Transformable" syncable="YES"/>
         <attribute name="rawMessageObject" optional="YES" attributeType="Transformable" syncable="YES"/>
         <attribute name="title" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="unread" optional="YES" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
-        <attribute name="unreadClient" optional="YES" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="unread" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="unreadClient" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="YES" syncable="YES"/>
     </entity>
     <elements>
         <element name="UAInboxMessage" positionX="-63" positionY="-18" width="128" height="210"/>


### PR DESCRIPTION
Since 8.4.2, new message center messages show up as read in the inbox. I tracked this down to a default value for the `unreadClient` field that was dropped during the recent refactor in 69e5f7f63db4ce276158e760a86ab4d5f5ebd201.

I added default values for all boolean properties and made them non-optional as per recommendation in the [Core Data Programming guide](https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/CoreData/KeyConcepts.html).

> You can specify that an attribute is optional—that is, it is not required to have a value. In general, however, avoid doing so, especially for numeric values. Typically, you can get better results using a mandatory attribute with a default value—defined in the attribute—of 0. The reason for this is that SQL has special comparison behavior for NULL that is unlike Objective-C’s nil. NULL in a database is not the same as 0, and searches for 0 do not match columns with NULL. Moreover, NULL in a database is not equivalent to an empty string or empty data blob.

In my testing, that fixed the problem without the need for a new model version or migration.