### PR TITLE
Do not block main thread

### DIFF
--- a/AirshipKit/AirshipKit/common/UAPush.m
+++ b/AirshipKit/AirshipKit/common/UAPush.m
@@ -1102,7 +1102,7 @@ NSString *const UAChannelUpdatedEventChannelKey = @"com.urbanairship.push.channe
     if ([NSThread isMainThread]) {
         result = block();
     } else {
-        dispatch_sync(dispatch_get_main_queue(), ^{
+        dispatch_async(dispatch_get_main_queue(), ^{
             result = block();
         });
     }


### PR DESCRIPTION
My app is launched with an initial animation and while it's presented some requests to the server are made.

If I call takeOff in a secondary thread and it's not finished yet, Urban Airship blocks the main thread so my requests' completion blocks are not called and the app is not able to start.

I don't know if this change could affect another scenarios, but please consider it.

Thanks!