### PR TITLE
Add nil check around completion block that's annotated as nullable in UAMessageCenterMessageViewController

### DIFF
--- a/AirshipKit/AirshipKit/ios/UADefaultMessageCenterMessageViewController.m
+++ b/AirshipKit/AirshipKit/ios/UADefaultMessageCenterMessageViewController.m
@@ -235,7 +235,9 @@ typedef enum MessageState {
     } withFailureBlock:^{
         dispatch_async(dispatch_get_main_queue(),^{
             [weakSelf hideLoadingIndicator];
-            errorCompletion();
+            if (errorCompletion) {
+                errorCompletion();
+            }
         });
         return;
     }];

--- a/AirshipKit/AirshipKit/ios/UAMessageCenterMessageViewController.m
+++ b/AirshipKit/AirshipKit/ios/UAMessageCenterMessageViewController.m
@@ -225,7 +225,9 @@ static NSString *urlForBlankPage = @"about:blank";
     } withFailureBlock:^{
         dispatch_async(dispatch_get_main_queue(),^{
             [weakSelf hideLoadingIndicator];
-            errorCompletion();
+            if (errorCompletion) {
+                errorCompletion();
+            }
         });
         return;
     }];


### PR DESCRIPTION
UAMessageCenterMessageViewProtocol.h has the following declaration on or around line 40:

- (void)loadMessageForID:(NSString *)messageID onlyIfChanged:(BOOL)onlyIfChanged onError:(nullable void (^)(void))errorCompletion;

The errorCompletion parameter is annotated as nullable. However, at the call sites in UAMessageCenterMessageViewController.m ~line 228 and UADefaultMessageCenterMessageViewController.m ~line 238, no nil check is performed.

This PR adds the check.