### PR TITLE
Fix warning about unused variable

### DIFF
--- a/AirshipKit/AirshipKit/ios/UAMessageCenterListViewController.m
+++ b/AirshipKit/AirshipKit/ios/UAMessageCenterListViewController.m
@@ -830,7 +830,6 @@
     [cell setData:message];
 
     UIImageView *localImageView = cell.listIconView;
-    UITableView *strongMessageTable = self.messageTable;
 
     if ([self.iconCache objectForKey:[self iconURLStringForMessage:message]]) {
         localImageView.image = [self.iconCache objectForKey:[self iconURLStringForMessage:message]];


### PR DESCRIPTION
I think this was a copy/paste oversight as the delegate method passes in a strong reference to the tableView anyway.