### PR TITLE
Enable building AirshipAppExtensions as static library through Cocoapods

### DIFF
--- a/AirshipAppExtensions/AirshipAppExtensions/AirshipAppExtensions.h
+++ b/AirshipAppExtensions/AirshipAppExtensions/AirshipAppExtensions.h
@@ -8,7 +8,5 @@ FOUNDATION_EXPORT double AirshipAppExtensionsVersionNumber;
 //! Project version string for AirshipAppExtensions.
 FOUNDATION_EXPORT const unsigned char AirshipAppExtensionsVersionString[];
 
-#import <AirshipAppExtensions/UAMediaAttachmentExtension.h>
-#import <AirshipAppExtensions/UAMediaAttachmentPayload.h>
-
-
+#import "UAMediaAttachmentExtension.h"
+#import "UAMediaAttachmentPayload.h"


### PR DESCRIPTION
I've updated the AirshipAppExtensions module header to be in line with AirshipKit module header and enable building as a static library through Cocoapods. This shouldn't affect building as a normal dynamic framework, since AirshipKit already used this #import format. I tested using Xcode 9.3 and Cocoapods 1.5.2.