### PR TITLE
Add ability to disable message link previews and callouts

### DIFF
--- a/AirshipKit/AirshipKit/ios/UAMessageCenter.h
+++ b/AirshipKit/AirshipKit/ios/UAMessageCenter.h
@@ -32,6 +32,11 @@
  */
 @property (nonatomic, strong) NSPredicate *filter;
 
+/**
+ * Disables 3D touching and long pressing on links in messages.
+ */
+@property (nonatomic) BOOL disableMessageLinkPreviewAndCallouts;
+
 ///---------------------------------------------------------------------------------------
 /// @name Default Message Center Factory
 ///---------------------------------------------------------------------------------------

--- a/AirshipKit/AirshipKit/ios/UAMessageCenterMessageViewController.m
+++ b/AirshipKit/AirshipKit/ios/UAMessageCenterMessageViewController.m
@@ -4,6 +4,7 @@
 #import "UAWKWebViewNativeBridge.h"
 #import "UAInbox.h"
 #import "UAirship.h"
+#import "UAMessageCenter.h"
 #import "UAInboxMessageList.h"
 #import "UAInboxMessage.h"
 #import "UAUtils+Internal.h"
@@ -106,6 +107,7 @@ typedef enum MessageState {
     self.nativeBridge = [[UAWKWebViewNativeBridge alloc] init];
     self.nativeBridge.forwardDelegate = self;
     self.webView.navigationDelegate = self.nativeBridge;
+    self.webView.allowsLinkPreview = ![UAirship messageCenter].disableMessageLinkPreviewAndCallouts;
 
     if (@available(iOS 10.0, tvOS 10.0, *)) {
         // Allow the webView to detect data types (e.g. phone numbers, addresses) at will
@@ -427,6 +429,11 @@ static NSString *urlForBlankPage = @"about:blank";
     if (self.messageState != LOADING) {
         UA_LWARN(@"WARNING: messageState = %u. Should be \"LOADING\"",self.messageState);
     }
+    
+    if ([UAirship messageCenter].disableMessageLinkPreviewAndCallouts) {
+        [self.webView evaluateJavaScript:@"document.body.style.webkitTouchCallout='none';" completionHandler:nil];
+    }
+    
     if ([wv.URL.absoluteString isEqualToString:urlForBlankPage]) {
         [self loadMessageIntoWebView];
         return;


### PR DESCRIPTION
My team and I noticed that when 3D touching a deep link in a message in the message center the web view would open a preview of the link in Safari, however the shown preview would not be of some Urban Airship login, as seen in the attached screenshot. 

Also, long pressing on the link would bring up an action sheet with various actions to perform with the link (also seen in one of the attached screenshots), however interacting with these actions had some unexpected behaviour. For example, tapping on the "open" option would simply dismiss the message center, and it also seem to leave it in an unexpected state as it would no longer be possible to present the message center until the app was restarted.

In response to these two issues, I've created this pull request to provide the option to disable the 3D touch and long press actions on links shown in the message center.

![3dtouch](https://user-images.githubusercontent.com/22305506/41612017-dd4e0b76-73ae-11e8-955c-9dd1b8e4809a.png)
![longpress](https://user-images.githubusercontent.com/22305506/41612018-dd6b0f6e-73ae-11e8-995e-54d4ef8335ba.png)