### PR TITLE
Accessibility improvements to In App Messaging

### DIFF
--- a/AirshipKit/AirshipKit/ios/UAInAppMessageDismissButton.m
+++ b/AirshipKit/AirshipKit/ios/UAInAppMessageDismissButton.m
@@ -29,6 +29,8 @@ CGFloat const CircleTransparency = 0.25;
     if (self) {
         self.userInteractionEnabled = YES;
 
+        self.accessibilityLabel = @"Dismiss";
+
         // Default to dark gray if provided color is nil
         self.dismissButtonColor = color ?: [UIColor darkGrayColor];
         self.closeIcon = [UIImage imageNamed:iconImageName];

--- a/AirshipKit/AirshipKit/ios/UAInAppMessageModalViewController.m
+++ b/AirshipKit/AirshipKit/ios/UAInAppMessageModalViewController.m
@@ -462,6 +462,8 @@ double const DefaultModalAnimationDuration = 0.2;
 
     // will make opaque as part of animation when view appears
     self.view.alpha = 0;
+    // disable voiceover interactions with visible items beneath the modal
+    self.view.accessibilityViewIsModal = YES;
 
     if (self.displayFullScreen) {
         // Detect view type


### PR DESCRIPTION
Declare UAInAppMessageModalViewController to be a modal to disable voiceover interactions with visible items beneath it
Add accessibility label to UAInAppMessageDismissButton

### What do these changes do?
Fix two issues with In App Messaging:
* Declare UAInAppMessageModalViewController to be a modal, so that you can't interact with anything beneath while in voiceover mode
* Add an accessibility label to UAInAppMessageDismissButton so voiceover users can tell what it does

### Why are these changes necessary?
These changes improve accessibility

### How did you verify these changes?
Triggered an In App Message modal through In App Automation

#### Verification Screenshots:
n/a

### Anything else a reviewer should know?
n/a
