### PR TITLE
Fix issue where the main thread checker trips when authorizing notifications

### DIFF
--- a/AirshipKit/AirshipKit/common/UAAPNSRegistration.m
+++ b/AirshipKit/AirshipKit/common/UAAPNSRegistration.m
@@ -79,7 +79,9 @@
     [[UNUserNotificationCenter currentNotificationCenter] requestAuthorizationWithOptions:normalizedOptions
                                                                         completionHandler:^(BOOL granted, NSError * _Nullable error) {
                                                                             [self getAuthorizedSettingsWithCompletionHandler:^(UAAuthorizedNotificationSettings authorizedSettings) {
-                                                                                [self.registrationDelegate notificationRegistrationFinishedWithAuthorizedSettings:authorizedSettings];
+                                                                                dispatch_async(dispatch_get_main_queue(), ^{
+                                                                                    [self.registrationDelegate notificationRegistrationFinishedWithAuthorizedSettings:authorizedSettings];
+                                                                                });
                                                                             }];
                                                                         }];
 }


### PR DESCRIPTION
### What do these changes do?
Update callback UAAPNSRegistration to dispatch on main thread since UNUserNotificationCenter callbacks are executed on main thread and this has the potential to produce a warning from the main thread checker.

### Why are these changes necessary?
UIKit methods are required to be called from the main thread only.

### How did you verify these changes?
Run the Swift example app and enabled push notification with and without the change. I also activated "Main Thread Checker", "Pause on issues" under Scheme -> Diagnostics -> Runtime API Checking.

#### Verification Screenshots:
<img width="585" alt="screen shot 2018-09-17 at 3 24 46 pm" src="https://user-images.githubusercontent.com/3142400/45646399-2e067700-ba91-11e8-8203-a356aeac9fea.png">

### Anything else a reviewer should know?
n/a
