### PR TITLE
Fix for issue #196

### DIFF
--- a/AirshipKit/AirshipKit/ios/UAInAppMessageResizableViewController+Internal.h
+++ b/AirshipKit/AirshipKit/ios/UAInAppMessageResizableViewController+Internal.h
@@ -29,6 +29,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property (strong, nonatomic, nullable) UIWindow *topWindow;
 
 /**
+ * The old window before the new modal window is made visible
+ */
+@property (strong, nonatomic, nullable) UIWindow *oldWindow;
+
+/**
  * The background color to be applied to the shade view when the app is in full screen display.
  */
 @property (strong, nonatomic) UIColor *backgroundColor;

--- a/AirshipKit/AirshipKit/ios/UAInAppMessageResizableViewController.m
+++ b/AirshipKit/AirshipKit/ios/UAInAppMessageResizableViewController.m
@@ -217,7 +217,9 @@ double const DefaultResizableViewAnimationDuration = 0.2;
 
     // add this view controller to the window
     self.topWindow.rootViewController = self;
-
+    
+    self.oldWindow = [[UIApplication sharedApplication] keyWindow];
+    
     // show the window
     [self.topWindow makeKeyAndVisible];
 }
@@ -261,6 +263,7 @@ double const DefaultResizableViewAnimationDuration = 0.2;
         self.isShowing = NO;
         [self.view removeFromSuperview];
         self.topWindow = nil;
+        [self.oldWindow makeKeyAndVisible];
     }];
 }
 


### PR DESCRIPTION

### What do these changes do?
Grabs a reference to the existing window to make key after dismissing the in app modal window

### Why are these changes necessary?
Necessary to fix issue #196 

### How did you verify these changes?
I repeated the the steps to reproduce listed in the above ticket and the issue no longer occurs. I also verified that the modal still appears and functions correctly
