### PR TITLE
Update Notification Extension Submodule name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ $ pod install
 
 In order to take advantage of notification attachments, you will need to create a notification service extension
 alongside your main application. Most of the work is already done for you, but since this involves creating a new target there
-are a few additional steps. First create a new "Notification Service Extension" target. Then add AirshipExtensions/ServiceExtension
+are a few additional steps. First create a new "Notification Service Extension" target. Then add AirshipExtensions/NotificationService
 to the new target:
 
 ```txt
@@ -89,7 +89,7 @@ use_frameworks!
 
 # Airship SDK
 target "<Your Service Extension Target Name>" do
-  pod 'AirshipExtensions/ServiceExtension'
+  pod 'AirshipExtensions/NotificationService'
 end
 ```
 


### PR DESCRIPTION
Hey 👋 Just stumbled over this:
When following the readme to embed the Notification extension module, `pod install` fails, because 
`CocoaPods could not find compatible versions for pod "AirshipExtensions/ServiceExtension"`

Looking at the [current spec of AirshipExtensions](https://github.com/CocoaPods/Specs/blob/31617e255747403a1172e24c73eb1576bd40e500/Specs/d/c/5/AirshipExtensions/13.0.1/AirshipExtensions.podspec.json), it seems like it has been renamed to `NotificationService` and indeed, `pod install` succeeds when using `pod 'AirshipExtensions/NotificationService'`.


<!--

Please fill out this template when submitting an pull request.

All lines beginning with an ℹ symbol indicate information that's
important for you to provide to ensure your pull request is reviewed
as quickly and efficiently as possible.

-->

### What do these changes do?
<!-- ℹ Please provide a description of your changes here. -->
Update the README

### Why are these changes necessary?
<!-- ℹ Please provide a concise description of why your changes are
necessary here. -->
So others don't have to debug like I did

### How did you verify these changes?
<!-- ℹ Please provide any relevant steps to verify or test your work. Make
this description clear enough so someone unfamiliar with your work could
verify for you. -->
Ran `pod install` succesfully

#### Verification Screenshots:
<!-- ℹ If applicable, please provide screenshots here. -->

### Anything else a reviewer should know?
<!-- ℹ Please provide any additional notes for the reviewer here. -->
