### PR TITLE
Fix "MobileCoreServices has been renamed" warning

### DIFF
--- a/Airship.podspec
+++ b/Airship.podspec
@@ -25,7 +25,7 @@ Pod::Spec.new do |s|
       core.ios.private_header_files   = "Airship/AirshipCore/Source/common/**/*+Internal*.h", "Airship/AirshipCore/Source/ios/**/*+Internal*.h"
       core.tvos.private_header_files  = "Airship/AirshipCore/Source/common/**/*+Internal*.h", "Airship/AirshipCore/Source/tvos/**/*+Internal*.h"
       core.libraries                  = "z", "sqlite3"
-      core.frameworks                 = "UserNotifications", "CFNetwork", "CoreGraphics", "Foundation", "MobileCoreServices", "Security", "SystemConfiguration", "UIKit", "CoreData"
+      core.frameworks                 = "UserNotifications", "CFNetwork", "CoreGraphics", "Foundation", "Security", "SystemConfiguration", "UIKit", "CoreData"
       core.ios.frameworks             = "WebKit", "CoreTelephony"
    end
 


### PR DESCRIPTION
### What changes have been made?

Fix the warning that occurs in Xcode 11.4, when Airship is installed via CocoaPods, by removing explicit linking of the MobileCoreServices framework.

![airship-xcode](https://user-images.githubusercontent.com/31985645/82655385-ffec1980-9c19-11ea-93c3-f974c9255157.png)

### Why are these changes necessary?

In iOS 12+ (also tvOS 12+ and watchOS 5+), Apple merged MobileCoreServices into CoreServices (previously available on macOS only). In Xcode 11.4 (using the iOS 13.4 SDK), the MobileCoreServices framework still exists but points to CoreServices, and will display a warning.

### Will these changes break anything?

As stated in more detail [here](https://github.com/AFNetworking/AFNetworking/pull/4532), the issue is not in importing the framework, only in explicitly linking it. Standard modules such as UIKit, CoreGraphics, WebKit, and CoreServices do not need to be specified as they will automatically be linked if needed.