### PR TITLE
Persist notificationOptions for subsequent starts.

### DIFF
--- a/Airship/AirshipCore/Source/Internal/UAPush.m
+++ b/Airship/AirshipCore/Source/Internal/UAPush.m
@@ -20,6 +20,7 @@
 #import "UASemaphore.h"
 #import "UAPrivacyManager.h"
 
+NSString *const UAUserPushNotificationsOptionsKey = @"UAUserPushNotificationsOptions";
 NSString *const UAUserPushNotificationsEnabledKey = @"UAUserPushNotificationsEnabled";
 NSString *const UABackgroundPushNotificationsEnabledKey = @"UABackgroundPushNotificationsEnabled";
 NSString *const UAExtendedPushNotificationPermissionEnabledKey = @"UAExtendedPushNotificationPermissionEnabled";
@@ -117,10 +118,12 @@ NSTimeInterval const UADeviceTokenRegistrationWaitTime = 10;
 
         self.shouldUpdateAPNSRegistration = YES;
 
-        self.notificationOptions = UANotificationOptionBadge;
+        if (![self.dataStore objectForKey:UAUserPushNotificationsOptionsKey]) {
+          self.notificationOptions = UANotificationOptionBadge;
 #if !TARGET_OS_TV  // Sound and Alert not supported on tvOS
-        self.notificationOptions = self.notificationOptions|UANotificationOptionSound|UANotificationOptionAlert;
+          self.notificationOptions = self.notificationOptions|UANotificationOptionSound|UANotificationOptionAlert;
 #endif
+      }
 
         [self observeNotificationCenterEvents];
 
@@ -491,8 +494,12 @@ NSTimeInterval const UADeviceTokenRegistrationWaitTime = 10;
 }
 
 - (void)setNotificationOptions:(UANotificationOptions)notificationOptions {
-    _notificationOptions = notificationOptions;
+    [self.dataStore setObject:[NSNumber numberWithUnsignedInteger:notificationOptions] forKey:UAUserPushNotificationsOptionsKey];
     self.shouldUpdateAPNSRegistration = YES;
+}
+
+- (UANotificationOptions)notificationOptions {
+    return [(NSNumber *)[self.dataStore objectForKey:UAUserPushNotificationsOptionsKey] unsignedIntegerValue];
 }
 
 - (void)setRegistrationDelegate:(id<UARegistrationDelegate>)registrationDelegate {


### PR DESCRIPTION
### What do these changes do?
ℹ Persist already set `notificationOptions` so when the app starts again, the same values are used.

### Why are these changes necessary?
ℹ After setting .provisional notifications, on a following app start `notificationOptions` get replaced with the defaults, so the permissions dialog is shown.
ℹ I would expect the popup to be shown only after the host app removes the `.provisional` option.

### How did you verify these changes?
ℹ In the SwiftSample, set the notifications options to `[.provisional]`; force closed the app and restarted it, observed the permissions dialog wasn't shown.
ℹ Run the `Airship.xcworkspace` unit tests, all run.

#### Verification Screenshots:
ℹ I don't have a screenshot at the moment but I can provide one if it's important.

### Anything else a reviewer should know?
ℹ I didn't find `./scripts/build.sh` and `scripts/run_ci_tasks.sh`, and didn't try running other scripts, just checked by running the SwiftSample app and unit tests from Xcode.
