### PR TITLE
Remove use of deprecated API UI_USER_INTERFACE_IDIOM()

### DIFF
--- a/Airship/AirshipAutomation/Source/UAInAppMessageResizableViewController.m
+++ b/Airship/AirshipAutomation/Source/UAInAppMessageResizableViewController.m
@@ -234,7 +234,7 @@ static double const DefaultResizableViewAnimationDuration = 0.2;
 
     self.displayFullScreen = false;
     if (self.allowFullScreenDisplay) {
-        if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
+        if (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad) {
             if (self.extendFullScreenLargeDevice) {
                 self.displayFullScreen = true;
             }


### PR DESCRIPTION
<!--

Please fill out this template when submitting an pull request.

All lines beginning with an ℹ symbol indicate information that's
important for you to provide to ensure your pull request is reviewed
as quickly and efficiently as possible.

-->

### What do these changes do?
<!-- ℹ Please provide a description of your changes here. -->
Remove use of [deprecated](https://developer.apple.com/documentation/uikit/1620016-ui_user_interface_idiom) `UI_USER_INTERFACE_IDIOM()` function and replace with UIDevice's [userInterfaceIdiom](https://developer.apple.com/documentation/uikit/uidevice/1620037-userinterfaceidiom) property introduced in iOS 3.2

### Why are these changes necessary?
<!-- ℹ Please provide a concise description of why your changes are
necessary here. -->
Starting Xcode 13.3 when creating an archive the deprecated API throws a compile time error and the only way to fix it is to replace with the new api. [Reference](https://developer.apple.com/forums/thread/702200)

### How did you verify these changes?
<!-- ℹ Please provide any relevant steps to verify or test your work. Make
this description clear enough so someone unfamiliar with your work could
verify for you. -->
There was no need to verify as these methods have always been interchangeable.

#### Verification Screenshots:
<!-- ℹ If applicable, please provide screenshots here. -->

### Anything else a reviewer should know?
<!-- ℹ Please provide any additional notes for the reviewer here. -->
