### PR TITLE
[GH-321] Better logging

### DIFF
--- a/Airship/Airship.xcodeproj/project.pbxproj
+++ b/Airship/Airship.xcodeproj/project.pbxproj
@@ -427,8 +427,6 @@
 		6E43217F26EA84BE009228AB /* UACompression.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E43217026EA84BE009228AB /* UACompression.m */; };
 		6E43218026EA84BE009228AB /* UAActionArguments+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 6E43217126EA84BE009228AB /* UAActionArguments+Internal.h */; };
 		6E43218126EA84BE009228AB /* UAActionArguments+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 6E43217126EA84BE009228AB /* UAActionArguments+Internal.h */; };
-		6E43218226EA84BE009228AB /* UAGlobal.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E43217226EA84BE009228AB /* UAGlobal.m */; };
-		6E43218326EA84BE009228AB /* UAGlobal.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E43217226EA84BE009228AB /* UAGlobal.m */; };
 		6E43218426EA84BE009228AB /* UAJavaScriptCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E43217326EA84BE009228AB /* UAJavaScriptCommand.m */; };
 		6E43218526EA84BE009228AB /* UAJavaScriptCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E43217326EA84BE009228AB /* UAJavaScriptCommand.m */; };
 		6E43218626EA84BE009228AB /* UAActionResult.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E43217426EA84BE009228AB /* UAActionResult.m */; };
@@ -1061,6 +1059,14 @@
 		6EEAE81624CF93150046E311 /* UAScheduleDeferredData.m in Sources */ = {isa = PBXBuildFile; fileRef = 6EEAE81224CF93140046E311 /* UAScheduleDeferredData.m */; };
 		6EEAE81824CF9FBF0046E311 /* UAScheduleDeferredDataTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 6EEAE81724CF9FBF0046E311 /* UAScheduleDeferredDataTest.m */; };
 		6EF02DF02714EB500008B6C9 /* Thomas.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EF02DEF2714EB500008B6C9 /* Thomas.swift */; };
+		6EF1933C2838062B005F192A /* AirshipLogHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EF1933B2838062B005F192A /* AirshipLogHandler.swift */; };
+		6EF1933E28380644005F192A /* DefaultLogHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EF1933D28380644005F192A /* DefaultLogHandler.swift */; };
+		6EF1933F28380644005F192A /* DefaultLogHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EF1933D28380644005F192A /* DefaultLogHandler.swift */; };
+		6EF1934028380648005F192A /* AirshipLogHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EF1933B2838062B005F192A /* AirshipLogHandler.swift */; };
+		6EF1934528380BA0005F192A /* UALegacyLoggingBridge.m in Sources */ = {isa = PBXBuildFile; fileRef = 6EF1934228380BA0005F192A /* UALegacyLoggingBridge.m */; };
+		6EF1934628380BA0005F192A /* UALegacyLoggingBridge.m in Sources */ = {isa = PBXBuildFile; fileRef = 6EF1934228380BA0005F192A /* UALegacyLoggingBridge.m */; };
+		6EF1934828380BE1005F192A /* UALegacyLoggingBridge.h in Headers */ = {isa = PBXBuildFile; fileRef = 6EF1934728380BE1005F192A /* UALegacyLoggingBridge.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6EF1934928380BE1005F192A /* UALegacyLoggingBridge.h in Headers */ = {isa = PBXBuildFile; fileRef = 6EF1934728380BE1005F192A /* UALegacyLoggingBridge.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6EF27DD927306C9100548DA3 /* AirshipToggle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EF27DD827306C9100548DA3 /* AirshipToggle.swift */; };
 		6EF27DDB27306CA600548DA3 /* AirshipCheckboxToggleStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EF27DDA27306CA600548DA3 /* AirshipCheckboxToggleStyle.swift */; };
 		6EF27DDC27306CA600548DA3 /* AirshipCheckboxToggleStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EF27DDA27306CA600548DA3 /* AirshipCheckboxToggleStyle.swift */; };
@@ -2020,7 +2026,6 @@
 		6E43216F26EA84BE009228AB /* UAActionArguments.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = UAActionArguments.m; path = Internal/UAActionArguments.m; sourceTree = "<group>"; };
 		6E43217026EA84BE009228AB /* UACompression.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = UACompression.m; path = Internal/UACompression.m; sourceTree = "<group>"; };
 		6E43217126EA84BE009228AB /* UAActionArguments+Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "UAActionArguments+Internal.h"; path = "Internal/UAActionArguments+Internal.h"; sourceTree = "<group>"; };
-		6E43217226EA84BE009228AB /* UAGlobal.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = UAGlobal.m; path = Internal/UAGlobal.m; sourceTree = "<group>"; };
 		6E43217326EA84BE009228AB /* UAJavaScriptCommand.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = UAJavaScriptCommand.m; path = Internal/UAJavaScriptCommand.m; sourceTree = "<group>"; };
 		6E43217426EA84BE009228AB /* UAActionResult.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = UAActionResult.m; path = Internal/UAActionResult.m; sourceTree = "<group>"; };
 		6E43217526EA84BE009228AB /* UASwizzler+Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "UASwizzler+Internal.h"; path = "Internal/UASwizzler+Internal.h"; sourceTree = "<group>"; };
@@ -2360,6 +2365,10 @@
 		6EEAE81224CF93140046E311 /* UAScheduleDeferredData.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = UAScheduleDeferredData.m; sourceTree = "<group>"; };
 		6EEAE81724CF9FBF0046E311 /* UAScheduleDeferredDataTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = UAScheduleDeferredDataTest.m; sourceTree = "<group>"; };
 		6EF02DEF2714EB500008B6C9 /* Thomas.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Thomas.swift; sourceTree = "<group>"; };
+		6EF1933B2838062B005F192A /* AirshipLogHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AirshipLogHandler.swift; sourceTree = "<group>"; };
+		6EF1933D28380644005F192A /* DefaultLogHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultLogHandler.swift; sourceTree = "<group>"; };
+		6EF1934228380BA0005F192A /* UALegacyLoggingBridge.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = UALegacyLoggingBridge.m; path = Internal/UALegacyLoggingBridge.m; sourceTree = "<group>"; };
+		6EF1934728380BE1005F192A /* UALegacyLoggingBridge.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = UALegacyLoggingBridge.h; path = Public/UALegacyLoggingBridge.h; sourceTree = "<group>"; };
 		6EF27DD827306C9100548DA3 /* AirshipToggle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AirshipToggle.swift; sourceTree = "<group>"; };
 		6EF27DDA27306CA600548DA3 /* AirshipCheckboxToggleStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AirshipCheckboxToggleStyle.swift; sourceTree = "<group>"; };
 		6EF27DDD27306CB300548DA3 /* AirshipSwitchToggleStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AirshipSwitchToggleStyle.swift; sourceTree = "<group>"; };
@@ -3667,7 +3676,6 @@
 			children = (
 				6E87BDFD26E283840005D20D /* Airship.swift */,
 				6E87BE0026E283850005D20D /* DeepLinkDelegate.swift */,
-				6E87BDFE26E283840005D20D /* LogLevel.swift */,
 				6E6ED14F2683DBC200A2CBD0 /* AirshipCoreResources.swift */,
 				6E6ED1502683DBC300A2CBD0 /* AirshipVersion.swift */,
 				6E87BDB426DEE61F0005D20D /* ComponentDisableHelper.swift */,
@@ -3944,7 +3952,6 @@
 				6E43213826EA84A4009228AB /* UAEvent.h */,
 				6E43212A26EA84A4009228AB /* UAFeature.h */,
 				6E43213E26EA84A5009228AB /* UAGlobal.h */,
-				6E43217226EA84BE009228AB /* UAGlobal.m */,
 				6E43212C26EA84A4009228AB /* UAJavaScriptCommand.h */,
 				6E43217326EA84BE009228AB /* UAJavaScriptCommand.m */,
 				6E43213226EA84A4009228AB /* UAJavaScriptCommandDelegate.h */,
@@ -3958,6 +3965,8 @@
 				6E43216D26EA84BE009228AB /* UASwizzler.m */,
 				6E43217526EA84BE009228AB /* UASwizzler+Internal.h */,
 				6E43213926EA84A4009228AB /* UAURLAllowListScope.h */,
+				6EF1934228380BA0005F192A /* UALegacyLoggingBridge.m */,
+				6EF1934728380BE1005F192A /* UALegacyLoggingBridge.h */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -4462,12 +4471,12 @@
 		6E937300237615B400AA9C2A /* Source */ = {
 			isa = PBXGroup;
 			children = (
+				6EF1933828380086005F192A /* Logger */,
 				6E062CFF27165642001A74A1 /* Thomas */,
 				6E43218E26EA89B5009228AB /* AirshipCore.h */,
 				A61517AD26A97419008A41C4 /* Subscription Lists */,
 				6E698E02267A799500654DB2 /* AirshipErrors.swift */,
 				6E8E1C9A26447B3800B11791 /* Lock.swift */,
-				6E698DEA26790AC300654DB2 /* AirshipLogger.swift */,
 				6E698DE826790AC300654DB2 /* PreferenceDataStore.swift */,
 				6E698DE726790A9C00654DB2 /* PrivacyManager */,
 				6EA57DEC25433C57005998C7 /* Tasks */,
@@ -4653,6 +4662,17 @@
 				6ED3C04420081013002A746B /* UAInAppMessageCustomDisplayContentTest.m */,
 			);
 			name = Custom;
+			sourceTree = "<group>";
+		};
+		6EF1933828380086005F192A /* Logger */ = {
+			isa = PBXGroup;
+			children = (
+				6E87BDFE26E283840005D20D /* LogLevel.swift */,
+				6E698DEA26790AC300654DB2 /* AirshipLogger.swift */,
+				6EF1933B2838062B005F192A /* AirshipLogHandler.swift */,
+				6EF1933D28380644005F192A /* DefaultLogHandler.swift */,
+			);
+			name = Logger;
 			sourceTree = "<group>";
 		};
 		6EF27DD627306C6900548DA3 /* Forms */ = {
@@ -5373,6 +5393,7 @@
 				6E43215226EA84A5009228AB /* AirshipBasementLib.h in Headers */,
 				6E43215E26EA84A5009228AB /* UAURLAllowListScope.h in Headers */,
 				6E43214E26EA84A5009228AB /* UALocationProvider.h in Headers */,
+				6EF1934828380BE1005F192A /* UALegacyLoggingBridge.h in Headers */,
 				6E43215026EA84A5009228AB /* UAJavaScriptCommandDelegate.h in Headers */,
 				6E43216226EA84A5009228AB /* UASDKModule.h in Headers */,
 				6E43215626EA84A5009228AB /* UAActionPredicateProtocol.h in Headers */,
@@ -5406,6 +5427,7 @@
 				6E43215326EA84A5009228AB /* AirshipBasementLib.h in Headers */,
 				6E43215F26EA84A5009228AB /* UAURLAllowListScope.h in Headers */,
 				6E43214F26EA84A5009228AB /* UALocationProvider.h in Headers */,
+				6EF1934928380BE1005F192A /* UALegacyLoggingBridge.h in Headers */,
 				6E43215126EA84A5009228AB /* UAJavaScriptCommandDelegate.h in Headers */,
 				6E43216326EA84A5009228AB /* UASDKModule.h in Headers */,
 				6E43215726EA84A5009228AB /* UAActionPredicateProtocol.h in Headers */,
@@ -6727,6 +6749,7 @@
 				A61517C426B009D6008A41C4 /* SubscriptionListAPIClient.swift in Sources */,
 				8401769426C5671100373AF7 /* JSONMatcher.swift in Sources */,
 				6E739D6626B9BDC100BC6F6D /* ChannelBulkUpdateAPIClient.swift in Sources */,
+				6EF1933E28380644005F192A /* DefaultLogHandler.swift in Sources */,
 				6E15B6E426CC779A0099C92D /* RemoteConfigModuleAdapter.swift in Sources */,
 				6E46A27C272B63680089CDE3 /* ThomasEnvironment.swift in Sources */,
 				6E1D8AD126CC5D490049DACB /* RemoteConfig.swift in Sources */,
@@ -6807,6 +6830,7 @@
 				6E8BF45126852E4B009A8BD4 /* TaskRequestOptions.swift in Sources */,
 				6E1C9C45271F74E7009EF9EF /* BorderViewModifier.swift in Sources */,
 				6EC7E48D26A738C80038CFDD /* ContactData.swift in Sources */,
+				6EF1933C2838062B005F192A /* AirshipLogHandler.swift in Sources */,
 				6E664BA126C43F5400A2C8E5 /* ActivityViewController.swift in Sources */,
 				6E91B45226883B6E00DDB1A8 /* AppExitEvent.swift in Sources */,
 				6E698E5B267BF63B00654DB2 /* UIKitStateTrackerAdapter.swift in Sources */,
@@ -6863,13 +6887,13 @@
 			files = (
 				6E43217C26EA84BE009228AB /* UAActionArguments.m in Sources */,
 				6E43217626EA84BE009228AB /* UAKeychainUtils.m in Sources */,
-				6E43218226EA84BE009228AB /* UAGlobal.m in Sources */,
 				6E88EF042703D9B100469E2A /* UADisposable.m in Sources */,
 				6E43217E26EA84BE009228AB /* UACompression.m in Sources */,
 				6E43218426EA84BE009228AB /* UAJavaScriptCommand.m in Sources */,
 				6E43217A26EA84BE009228AB /* UAAutoIntegration.m in Sources */,
 				6E43218626EA84BE009228AB /* UAActionResult.m in Sources */,
 				6E43217826EA84BE009228AB /* UASwizzler.m in Sources */,
+				6EF1934528380BA0005F192A /* UALegacyLoggingBridge.m in Sources */,
 				6E88EF062703D9B100469E2A /* UAPadding.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -6880,13 +6904,13 @@
 			files = (
 				6E43217D26EA84BE009228AB /* UAActionArguments.m in Sources */,
 				6E43217726EA84BE009228AB /* UAKeychainUtils.m in Sources */,
-				6E43218326EA84BE009228AB /* UAGlobal.m in Sources */,
 				6E88EF052703D9B100469E2A /* UADisposable.m in Sources */,
 				6E43217F26EA84BE009228AB /* UACompression.m in Sources */,
 				6E43218526EA84BE009228AB /* UAJavaScriptCommand.m in Sources */,
 				6E43217B26EA84BE009228AB /* UAAutoIntegration.m in Sources */,
 				6E43218726EA84BE009228AB /* UAActionResult.m in Sources */,
 				6E43217926EA84BE009228AB /* UASwizzler.m in Sources */,
+				6EF1934628380BA0005F192A /* UALegacyLoggingBridge.m in Sources */,
 				6E88EF072703D9B100469E2A /* UAPadding.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -7429,6 +7453,7 @@
 				A6F6726126E1162F008C69C3 /* JSONMatcher.swift in Sources */,
 				6E698DF126790AC300654DB2 /* AirshipLogger.swift in Sources */,
 				6EB56C7D27AC4BBC00A7392F /* AssociatedChannel.swift in Sources */,
+				6EF1933F28380644005F192A /* DefaultLogHandler.swift in Sources */,
 				6ED80794273CA0C800D1F455 /* EnvironmentValues.swift in Sources */,
 				32515874272B038300DF8B44 /* Image.swift in Sources */,
 				6E510C262721DA86006D9126 /* ForegroundColorViewModifier.swift in Sources */,
@@ -7446,6 +7471,7 @@
 				A67F87D6268E07E800EF5F43 /* ContactAPIResponse.swift in Sources */,
 				6E152BCB2743235800788402 /* Icons.swift in Sources */,
 				6E510C1C2721DA6A006D9126 /* ViewFactory.swift in Sources */,
+				6EF1934028380648005F192A /* AirshipLogHandler.swift in Sources */,
 				6EF27DE42730E6F900548DA3 /* RadioInputController.swift in Sources */,
 				6E6ED1582683DBC300A2CBD0 /* ViewUtils.swift in Sources */,
 				6EF66D8F27657B3A00ABCB76 /* UrlInfo.swift in Sources */,

--- a/Airship/AirshipAutomation/Source/UAAutomationEngine.m
+++ b/Airship/AirshipAutomation/Source/UAAutomationEngine.m
@@ -1180,7 +1180,7 @@ static NSString * const UAAutomationEngineTaskExtrasIdentifier = @"identifier";
         }
 
         if (![self isScheduleConditionsSatisfied:schedule.delay]) {
-            UA_LDEBUG("Schedule %@ is not ready to execute. Conditions not satisfied", schedule.identifier);
+            UA_LDEBUG(@"Schedule %@ is not ready to execute. Conditions not satisfied", schedule.identifier);
             return;
         }
 
@@ -1188,13 +1188,13 @@ static NSString * const UAAutomationEngineTaskExtrasIdentifier = @"identifier";
 
         switch ([delegate isScheduleReadyToExecute:schedule]) {
             case UAAutomationScheduleReadyResultInvalidate: {
-                UA_LTRACE("Attempted to execute an invalid schedule %@", schedule.identifier);
+                UA_LTRACE(@"Attempted to execute an invalid schedule %@", schedule.identifier);
                 nextExecutionState = UAScheduleStatePreparingSchedule;
                 [self prepareScheduleWithIdentifier:schedule.identifier];
                 break;
             }
             case UAAutomationScheduleReadyResultContinue: {
-                UA_LTRACE("Executing schedule %@", schedule.identifier);
+                UA_LTRACE(@"Executing schedule %@", schedule.identifier);
                 [delegate executeSchedule:schedule completionHandler:^{
                     UA_STRONGIFY(self)
                     [self.automationStore getSchedule:schedule.identifier completionHandler:^(UAScheduleData *scheduleData) {
@@ -1207,11 +1207,11 @@ static NSString * const UAAutomationEngineTaskExtrasIdentifier = @"identifier";
                 break;
             }
             case UAAutomationScheduleReadyResultNotReady: {
-                UA_LTRACE("Schedule %@ not ready for execution", schedule.identifier);
+                UA_LTRACE(@"Schedule %@ not ready for execution", schedule.identifier);
                 break;
             }
             case UAAutomationScheduleReadyResultSkip: {
-                UA_LTRACE("Schedule %@ not ready for execution, resetting to idle", schedule.identifier);
+                UA_LTRACE(@"Schedule %@ not ready for execution, resetting to idle", schedule.identifier);
                 nextExecutionState = UAScheduleStateIdle;
                 break;
             }

--- a/Airship/AirshipAutomation/Source/UAInAppMessageAirshipLayoutDisplayContent.m
+++ b/Airship/AirshipAutomation/Source/UAInAppMessageAirshipLayoutDisplayContent.m
@@ -50,7 +50,7 @@ API_AVAILABLE(ios(13.0))
     [UAThomas validateWithJson:layout error:&thomasError];
     
     if (thomasError != nil) {
-        UA_LDEBUG("Invalid Airship layout %@", thomasError);
+        UA_LDEBUG(@"Invalid Airship layout %@", thomasError);
         if (error) {
             *error = thomasError;
         }

--- a/Airship/AirshipAutomation/Source/UAInAppMessageManager.m
+++ b/Airship/AirshipAutomation/Source/UAInAppMessageManager.m
@@ -390,7 +390,7 @@ NSString *const UAInAppMessageDisplayCoordinatorIsReadyKey = @"isReady";
 
     UAInAppMessageScheduleData *data = self.scheduleData[scheduleID];
     if (!data) {
-        UA_LERR("No data for schedule: %@", scheduleID);
+        UA_LERR(@"No data for schedule: %@", scheduleID);
         return UAAutomationScheduleReadyResultInvalidate;
     }
 
@@ -531,7 +531,7 @@ NSString *const UAInAppMessageDisplayCoordinatorIsReadyKey = @"isReady";
             onDismiss(resolution);
         }];
     } else {
-        UA_LWARN("Unable to display message, missing display method for schedule %@", scheduleID);
+        UA_LWARN(@"Unable to display message, missing display method for schedule %@", scheduleID);
     }
 }
 

--- a/Airship/AirshipAutomation/Source/UAInAppRemoteDataClient.m
+++ b/Airship/AirshipAutomation/Source/UAInAppRemoteDataClient.m
@@ -228,7 +228,7 @@ static NSString *const UAScheduleInfoFrequencyConstraintIDsKey = @"frequency_con
 
         NSString *scheduleID = [UAInAppRemoteDataClient parseScheduleID:message];
         if (!scheduleID.length) {
-            UA_LERR("Missing ID: %@", message);
+            UA_LERR(@"Missing ID: %@", message);
             continue;
         }
 
@@ -254,7 +254,7 @@ static NSString *const UAScheduleInfoFrequencyConstraintIDsKey = @"frequency_con
                                        completionHandler:^(BOOL result) {
                 dispatch_group_leave(dispatchGroup);
                 if (result) {
-                    UA_LTRACE("Updated in-app automation: %@", scheduleID);
+                    UA_LTRACE(@"Updated in-app automation: %@", scheduleID);
                 }
             }];
         } else if ([self isNewSchedule:message
@@ -296,7 +296,7 @@ static NSString *const UAScheduleInfoFrequencyConstraintIDsKey = @"frequency_con
                             completionHandler:^(BOOL result) {
                 dispatch_group_leave(dispatchGroup);
                 if (result) {
-                    UA_LTRACE("Ended in-app automation: %@", scheduleID);
+                    UA_LTRACE(@"Ended in-app automation: %@", scheduleID);
                 }
             }];
         }

--- a/Airship/AirshipAutomation/Source/UAScheduleData.m
+++ b/Airship/AirshipAutomation/Source/UAScheduleData.m
@@ -60,7 +60,7 @@ NSUInteger const UAScheduleDataVersion = 3;
 
 - (BOOL)verifyState:(UAScheduleState)state {
     if (![self checkState:state]) {
-        UA_LTRACE("Schedule %@ in invalid state. Expected %ld, actual %@", self.identifier, (long)state, self.executionState);
+        UA_LTRACE(@"Schedule %@ in invalid state. Expected %ld, actual %@", self.identifier, (long)state, self.executionState);
         return NO;
     } else {
         return YES;
@@ -68,7 +68,7 @@ NSUInteger const UAScheduleDataVersion = 3;
 }
 
 - (void)updateState:(UAScheduleState)state {
-    UA_LTRACE("Updating schedule %@ state from %@ to %ld", self.identifier, self.executionState, (long) state);
+    UA_LTRACE(@"Updating schedule %@ state from %@ to %ld", self.identifier, self.executionState, (long) state);
     self.executionState = @(state);
 }
 

--- a/Airship/AirshipBasement/Source/Internal/UAAutoIntegration.m
+++ b/Airship/AirshipBasement/Source/Internal/UAAutoIntegration.m
@@ -5,7 +5,6 @@
 #import "UAGlobal.h"
 
 static UAAutoIntegration *instance_;
-
 @interface UAAutoIntegrationDummyDelegate : NSObject<UNUserNotificationCenterDelegate>
 @end
 

--- a/Airship/AirshipBasement/Source/Internal/UAGlobal.m
+++ b/Airship/AirshipBasement/Source/Internal/UAGlobal.m
@@ -1,2 +1,0 @@
-#import "UAGlobal.h"
-NSInteger uaLogLevel = 5;

--- a/Airship/AirshipBasement/Source/Internal/UALegacyLoggingBridge.m
+++ b/Airship/AirshipBasement/Source/Internal/UALegacyLoggingBridge.m
@@ -5,13 +5,13 @@
 
 @implementation UALegacyLoggingBridge
 
-static LoggerBlock _loggerBlock = nil;
+static UALoggerBlock _loggerBlock = nil;
 
-+ (void)setLogger:(LoggerBlock)loggerBlock {
++ (void)setLogger:(UALoggerBlock)loggerBlock {
     _loggerBlock = loggerBlock;
 }
 
-+ (LoggerBlock)logger {
++ (UALoggerBlock)logger {
     return _loggerBlock;
 }
 
@@ -19,11 +19,11 @@ static LoggerBlock _loggerBlock = nil;
               fileID:(NSString *)fileID
             function:(NSString *)function
                 line:(NSUInteger)line
-             message:(NSString *)message {
+             message:(UAMessageBlock)messageBlock {
 
-    LoggerBlock loggerBlock = _loggerBlock;
+    UALoggerBlock loggerBlock = _loggerBlock;
     if (loggerBlock) {
-        loggerBlock(level, message, fileID, function, line);
+        loggerBlock(level, fileID, function, line, messageBlock);
     }
 }
 

--- a/Airship/AirshipBasement/Source/Internal/UALegacyLoggingBridge.m
+++ b/Airship/AirshipBasement/Source/Internal/UALegacyLoggingBridge.m
@@ -1,0 +1,30 @@
+/* Copyright Airship and Contributors */
+
+#import "UALegacyLoggingBridge.h"
+
+
+@implementation UALegacyLoggingBridge
+
+static LoggerBlock _loggerBlock = nil;
+
++ (void)setLogger:(LoggerBlock)loggerBlock {
+    _loggerBlock = loggerBlock;
+}
+
++ (LoggerBlock)logger {
+    return _loggerBlock;
+}
+
++ (void)logWithLevel:(NSInteger)level
+              fileID:(NSString *)fileID
+            function:(NSString *)function
+                line:(NSUInteger)line
+             message:(NSString *)message {
+
+    LoggerBlock loggerBlock = _loggerBlock;
+    if (loggerBlock) {
+        loggerBlock(level, message, fileID, function, line);
+    }
+}
+
+@end

--- a/Airship/AirshipBasement/Source/Internal/UALegacyLoggingBridge.m
+++ b/Airship/AirshipBasement/Source/Internal/UALegacyLoggingBridge.m
@@ -16,14 +16,13 @@ static UALoggerBlock _loggerBlock = nil;
 }
 
 + (void)logWithLevel:(NSInteger)level
-              fileID:(NSString *)fileID
             function:(NSString *)function
                 line:(NSUInteger)line
              message:(UAMessageBlock)messageBlock {
 
     UALoggerBlock loggerBlock = _loggerBlock;
     if (loggerBlock) {
-        loggerBlock(level, fileID, function, line, messageBlock);
+        loggerBlock(level, function, line, messageBlock);
     }
 }
 

--- a/Airship/AirshipBasement/Source/Internal/UASwizzler.m
+++ b/Airship/AirshipBasement/Source/Internal/UASwizzler.m
@@ -44,6 +44,8 @@
 - (void)swizzle:(SEL)selector implementation:(IMP)implementation {
     Method method = class_getInstanceMethod(self.class, selector);
     if (method) {
+       
+
         UA_LTRACE(@"Swizzling implementation for %@ class %@", NSStringFromSelector(selector), self.class);
         IMP existing = method_setImplementation(method, implementation);
         if (implementation != existing) {

--- a/Airship/AirshipBasement/Source/Internal/UASwizzler.m
+++ b/Airship/AirshipBasement/Source/Internal/UASwizzler.m
@@ -44,8 +44,6 @@
 - (void)swizzle:(SEL)selector implementation:(IMP)implementation {
     Method method = class_getInstanceMethod(self.class, selector);
     if (method) {
-       
-
         UA_LTRACE(@"Swizzling implementation for %@ class %@", NSStringFromSelector(selector), self.class);
         IMP existing = method_setImplementation(method, implementation);
         if (implementation != existing) {

--- a/Airship/AirshipBasement/Source/Public/AirshipBasementLib.h
+++ b/Airship/AirshipBasement/Source/Public/AirshipBasementLib.h
@@ -14,6 +14,7 @@
 #import "UAJavaScriptCommandDelegate.h"
 #import "UAJavaScriptEnvironmentProtocol.h"
 #import "UAKeychainUtils.h"
+#import "UALegacyLoggingBridge.h"
 #import "UALocationProvider.h"
 #import "UANativeBridgeExtensionDelegate.h"
 #import "UAPadding.h"

--- a/Airship/AirshipBasement/Source/Public/UAGlobal.h
+++ b/Airship/AirshipBasement/Source/Public/UAGlobal.h
@@ -4,7 +4,10 @@
 #import "UALegacyLoggingBridge.h"
 
 #define UA_LEVEL_LOG(level, fmt, ...) \
-     [UALegacyLoggingBridge logWithLevel:level message:[NSString stringWithFormat:fmt, ##__VA_ARGS__] fileID: @(__FILE__) function:@(__PRETTY_FUNCTION__) line:__LINE__];
+do { \
+   [UALegacyLoggingBridge logWithLevel:level fileID:@(__FILE__) function:@(__PRETTY_FUNCTION__) line:__LINE__ message:^NSString * { return [NSString stringWithFormat:fmt, ##__VA_ARGS__]; }]; \
+} while(0)
+
 
 #define UA_LTRACE(fmt, ...) UA_LEVEL_LOG(5, fmt, ##__VA_ARGS__)
 #define UA_LDEBUG(fmt, ...) UA_LEVEL_LOG(4, fmt, ##__VA_ARGS__)

--- a/Airship/AirshipBasement/Source/Public/UAGlobal.h
+++ b/Airship/AirshipBasement/Source/Public/UAGlobal.h
@@ -5,7 +5,7 @@
 
 #define UA_LEVEL_LOG(level, fmt, ...) \
 do { \
-   [UALegacyLoggingBridge logWithLevel:level fileID:@(__FILE__) function:@(__PRETTY_FUNCTION__) line:__LINE__ message:^NSString * { return [NSString stringWithFormat:fmt, ##__VA_ARGS__]; }]; \
+   [UALegacyLoggingBridge logWithLevel:level function:@(__PRETTY_FUNCTION__) line:__LINE__ message:^NSString * { return [NSString stringWithFormat:fmt, ##__VA_ARGS__]; }]; \
 } while(0)
 
 

--- a/Airship/AirshipBasement/Source/Public/UAGlobal.h
+++ b/Airship/AirshipBasement/Source/Public/UAGlobal.h
@@ -1,45 +1,16 @@
 /* Copyright Airship and Contributors */
 
 #import <UIKit/UIKit.h>
+#import "UALegacyLoggingBridge.h"
 
+#define UA_LEVEL_LOG(level, fmt, ...) \
+     [UALegacyLoggingBridge logWithLevel:level message:[NSString stringWithFormat:fmt, ##__VA_ARGS__] fileID: @(__FILE__) function:@(__PRETTY_FUNCTION__) line:__LINE__];
 
-#define UA_LEVEL_LOG_THREAD(level, levelString, fmt, ...) \
-    do { \
-        if (uaLogLevel >= level) { \
-            NSString *thread = ([[NSThread currentThread] isMainThread]) ? @"M" : @"B"; \
-            NSLog((@"[%@] [%@] => %s [Line %d] " fmt), levelString, thread, __PRETTY_FUNCTION__, __LINE__, ##__VA_ARGS__); \
-        } \
-    } while(0)
-
-#define UA_LEVEL_LOG_NO_THREAD(level, levelString, fmt, ...) \
-    do { \
-        if (uaLogLevel >= level) { \
-            NSLog((@"[%@] %s [Line %d] " fmt), levelString, __PRETTY_FUNCTION__, __LINE__, ##__VA_ARGS__); \
-        } \
-    } while(0)
-
-#define UA_LEVEL_LOG_IMPLEMENTATION(fmt, ...) \
-    do { \
-        if (uaLogLevel >= 1) { \
-            NSLog((@"🚨Airship Implementation Error🚨 - " fmt), ##__VA_ARGS__); \
-        } \
-    } while(0)
-
-//only log thread if #UA_LOG_THREAD is defined
-#ifdef UA_LOG_THREAD
-#define UA_LEVEL_LOG UA_LEVEL_LOG_THREAD
-#else
-#define UA_LEVEL_LOG UA_LEVEL_LOG_NO_THREAD
-#endif
-
-extern NSInteger uaLogLevel; // Default is UALogLevelError
-
-#define UA_LTRACE(fmt, ...) UA_LEVEL_LOG(5, @"T", fmt, ##__VA_ARGS__)
-#define UA_LDEBUG(fmt, ...) UA_LEVEL_LOG(4, @"D", fmt, ##__VA_ARGS__)
-#define UA_LINFO(fmt, ...) UA_LEVEL_LOG(3, @"I", fmt, ##__VA_ARGS__)
-#define UA_LWARN(fmt, ...) UA_LEVEL_LOG(2, @"W", fmt, ##__VA_ARGS__)
-#define UA_LERR(fmt, ...) UA_LEVEL_LOG(1, @"E", fmt, ##__VA_ARGS__)
-#define UA_LIMPERR(fmt, ...) UA_LEVEL_LOG_IMPLEMENTATION(fmt, ##__VA_ARGS__)
+#define UA_LTRACE(fmt, ...) UA_LEVEL_LOG(5, fmt, ##__VA_ARGS__)
+#define UA_LDEBUG(fmt, ...) UA_LEVEL_LOG(4, fmt, ##__VA_ARGS__)
+#define UA_LINFO(fmt, ...) UA_LEVEL_LOG(3, fmt, ##__VA_ARGS__)
+#define UA_LWARN(fmt, ...) UA_LEVEL_LOG(2, fmt, ##__VA_ARGS__)
+#define UA_LERR(fmt, ...) UA_LEVEL_LOG(1, fmt, ##__VA_ARGS__)
 #define UALOG UA_LDEBUG
 
 #define UA_WEAKIFY(var) __weak __typeof(var) UAWeak_##var = var;

--- a/Airship/AirshipBasement/Source/Public/UALegacyLoggingBridge.h
+++ b/Airship/AirshipBasement/Source/Public/UALegacyLoggingBridge.h
@@ -14,9 +14,9 @@ NS_ASSUME_NONNULL_BEGIN
 typedef NSString * _Nonnull(^UAMessageBlock)(void);
 
 /**
- * The logger block - log level,, fileID, function, line, message block
+ * The logger block - log level, function, line, message block
  */
-typedef void (^UALoggerBlock)(NSInteger, NSString *, NSString *, NSUInteger, UAMessageBlock);
+typedef void (^UALoggerBlock)(NSInteger, NSString *, NSUInteger, UAMessageBlock);
 
 /**
  * Set by Airship during takeOff
@@ -27,7 +27,6 @@ typedef void (^UALoggerBlock)(NSInteger, NSString *, NSString *, NSUInteger, UAM
  * Called by the macros in UAGlobal.h
  */
 + (void)logWithLevel:(NSInteger)level
-              fileID:(NSString *)fileID
             function:(NSString *)function
                 line:(NSUInteger)line
              message:(UAMessageBlock)messageBlock;

--- a/Airship/AirshipBasement/Source/Public/UALegacyLoggingBridge.h
+++ b/Airship/AirshipBasement/Source/Public/UALegacyLoggingBridge.h
@@ -11,24 +11,26 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface UALegacyLoggingBridge : NSObject
 
+typedef NSString * _Nonnull(^UAMessageBlock)(void);
+
 /**
- * The logger block - log level, log message, fileID, function, line
+ * The logger block - log level,, fileID, function, line, message block
  */
-typedef void (^LoggerBlock)(NSInteger, NSString *, NSString *, NSString *, NSUInteger);
+typedef void (^UALoggerBlock)(NSInteger, NSString *, NSString *, NSUInteger, UAMessageBlock);
 
 /**
  * Set by Airship during takeOff
  */
-@property (class, nonatomic, copy, nullable) LoggerBlock logger;
+@property (class, nonatomic, copy, nullable) UALoggerBlock logger;
 
 /**
  * Called by the macros in UAGlobal.h
  */
 + (void)logWithLevel:(NSInteger)level
-             message:(NSString *)message
               fileID:(NSString *)fileID
             function:(NSString *)function
-                line:(NSUInteger)line;
+                line:(NSUInteger)line
+             message:(UAMessageBlock)messageBlock;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Airship/AirshipBasement/Source/Public/UALegacyLoggingBridge.h
+++ b/Airship/AirshipBasement/Source/Public/UALegacyLoggingBridge.h
@@ -1,0 +1,34 @@
+/* Copyright Airship and Contributors */
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * Used to bridge logs from our legacy logging used in obj-c modules to the AirshipCore.AirshipLogger.
+ *
+ * @note For internal use only. :nodoc:
+ */
+@interface UALegacyLoggingBridge : NSObject
+
+/**
+ * The logger block - log level, log message, fileID, function, line
+ */
+typedef void (^LoggerBlock)(NSInteger, NSString *, NSString *, NSString *, NSUInteger);
+
+/**
+ * Set by Airship during takeOff
+ */
+@property (class, nonatomic, copy, nullable) LoggerBlock logger;
+
+/**
+ * Called by the macros in UAGlobal.h
+ */
++ (void)logWithLevel:(NSInteger)level
+             message:(NSString *)message
+              fileID:(NSString *)fileID
+            function:(NSString *)function
+                line:(NSUInteger)line;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Airship/AirshipCore/Source/Airship.swift
+++ b/Airship/AirshipCore/Source/Airship.swift
@@ -200,9 +200,9 @@ public class Airship : NSObject {
         
         self.logLevel = resolvedConfig.logLevel
 
-        UALegacyLoggingBridge.logger = { logLevel, message, fileID, function, line in
+        UALegacyLoggingBridge.logger = { logLevel, fileID, function, line, message in
             AirshipLogger.log(logLevel: LogLevel(rawValue: logLevel) ?? .none,
-                              message: message,
+                              message: message(),
                               fileID: fileID,
                               line: line,
                               function: function)
@@ -292,7 +292,7 @@ public class Airship : NSObject {
         let component = shared.airshipInstance.component(ofType: componentType)
         
         if (component == nil) {
-            assertionFailure("Misisng required component: \(componentType)")
+            assertionFailure("Missing required component: \(componentType)")
         }
         return component!
     }

--- a/Airship/AirshipCore/Source/Airship.swift
+++ b/Airship/AirshipCore/Source/Airship.swift
@@ -200,10 +200,10 @@ public class Airship : NSObject {
         
         self.logLevel = resolvedConfig.logLevel
 
-        UALegacyLoggingBridge.logger = { logLevel, fileID, function, line, message in
+        UALegacyLoggingBridge.logger = { logLevel, function, line, message in
             AirshipLogger.log(logLevel: LogLevel(rawValue: logLevel) ?? .none,
                               message: message(),
-                              fileID: fileID,
+                              fileID: "",
                               line: line,
                               function: function)
         }

--- a/Airship/AirshipCore/Source/Airship.swift
+++ b/Airship/AirshipCore/Source/Airship.swift
@@ -184,7 +184,6 @@ public class Airship : NSObject {
             return
         }
         
-        
         if (config == nil) {
             guard Bundle.main.path(forResource: "AirshipConfig", ofType: "plist") != nil else {
                 AirshipLogger.impError("AirshipConfig.plist file is missing. Unable to takeOff.")
@@ -200,6 +199,14 @@ public class Airship : NSObject {
         }
         
         self.logLevel = resolvedConfig.logLevel
+
+        UALegacyLoggingBridge.logger = { logLevel, message, fileID, function, line in
+            AirshipLogger.log(logLevel: LogLevel(rawValue: logLevel) ?? .none,
+                              message: message,
+                              fileID: fileID,
+                              line: line,
+                              function: function)
+        }
         
         AirshipLogger.info("Airship TakeOff! SDK Version \(AirshipVersion.get()), App Key: \(resolvedConfig.appKey), inProduction: \(resolvedConfig.inProduction)")
         
@@ -240,18 +247,32 @@ public class Airship : NSObject {
             NotificationCenter.default.post(name: airshipReadyNotification, object: nil)
         }
     }
-    
-    /// Sets the Airship log level. The log level defaults to `.debug` in developer mode,
+
+    /// Airship log handler. All Airship log will be routed through the handler.
+    ///
+    /// The default logger will os.Logger on iOS 14+, and `print` on older devices.
+    ///
+    /// Custom loggers should be set before takeOff.
+    @objc
+    public static var logHandler: AirshipLogHandler {
+        get {
+            return AirshipLogger.logHandler
+        }
+        set {
+            AirshipLogger.logHandler = newValue
+        }
+    }
+
+    /// Airship log level. The log level defaults to `.debug` in developer mode,
     /// and `.error` in production. Values set before `takeOff` will be overridden by
     /// the value from the AirshipConfig.
-    /// - Parameters:
-    ///     - logLevel: The log level. Use .none to disable all logs.
-    ///
     @objc
-    public static var logLevel: LogLevel = .error {
-        didSet {
-            uaLogLevel = logLevel.rawValue
-            AirshipLogger.logLevel = logLevel
+    public static var logLevel: LogLevel {
+        get {
+            return AirshipLogger.logLevel
+        }
+        set {
+            AirshipLogger.logLevel = newValue
         }
     }
     

--- a/Airship/AirshipCore/Source/AirshipLogHandler.swift
+++ b/Airship/AirshipCore/Source/AirshipLogHandler.swift
@@ -1,0 +1,19 @@
+/* Copyright Airship and Contributors */
+
+import Foundation
+
+/// Protocol used by Airship to log all log messages within the SDK.
+/// A custom log handlers should be set on `Airship.logHandler` before `Airship.takeOff`.
+@objc
+public protocol AirshipLogHandler {
+
+    /// Called to log a message.
+    /// - Parameters:
+    ///     - logLevel: The Airship log level.
+    ///     - message: The log message.
+    ///     - fileID: The file ID.
+    ///     - line: The line number.
+    ///     - function: The function.
+    @objc
+    func log(logLevel: LogLevel, message: String, fileID: String, line: UInt, function: String)
+}

--- a/Airship/AirshipCore/Source/AirshipLogHandler.swift
+++ b/Airship/AirshipCore/Source/AirshipLogHandler.swift
@@ -4,7 +4,7 @@ import Foundation
 
 /// Protocol used by Airship to log all log messages within the SDK.
 /// A custom log handlers should be set on `Airship.logHandler` before `Airship.takeOff`.
-@objc
+@objc(UAirshipLogHandler)
 public protocol AirshipLogHandler {
 
     /// Called to log a message.

--- a/Airship/AirshipCore/Source/AirshipLogger.swift
+++ b/Airship/AirshipCore/Source/AirshipLogger.swift
@@ -1,60 +1,55 @@
 /* Copyright Airship and Contributors */
 
 import Foundation
-import os
 
-/**
- * Airship logger.
- * - Note: For internal use only. :nodoc:
- */
-@objc(UAAirshipLogger)
-public class AirshipLogger : NSObject {
+///
+/// Airship logger.
+///
+/// - Note: For internal use only. :nodoc:
+public class AirshipLogger {
 
     static var logLevel: LogLevel = .error
+    static var logHandler: AirshipLogHandler = DefaultLogHandler()
 
-    @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
-    static let LOGGER = Logger(subsystem: Bundle.main.bundleIdentifier ?? "", category: "Airship")
-
-    public static func trace(_ message: String,
+    public static func trace(_ message: @autoclosure () -> String,
                              fileID: String = #fileID,
-                             line: Int = #line,
+                             line: UInt = #line,
                              function: String = #function) {
 
         log(logLevel: LogLevel.trace,
-            message: message,
+            message: message(),
             fileID: fileID,
             line: line,
             function: function)
     }
 
-    public static func debug(_ message: String,
+    public static func debug(_ message: @autoclosure () -> String,
                              fileID: String = #fileID,
-                             line: Int = #line,
+                             line: UInt = #line,
                              function: String = #function) {
 
         log(logLevel: LogLevel.debug,
-            message: message,
+            message: message(),
             fileID: fileID,
             line: line,
             function: function)
     }
 
-
-    public static func info(_ message: String,
+    public static func info(_ message: @autoclosure () -> String,
                             fileID: String = #fileID,
-                            line: Int = #line,
+                            line: UInt = #line,
                             function: String = #function) {
         log(logLevel: LogLevel.info,
-            message: message,
+            message: message(),
             fileID: fileID,
             line: line,
             function: function)
     }
-    
+
     public static func importantInfo(_ message: String,
-                            fileID: String = #fileID,
-                            line: Int = #line,
-                            function: String = #function) {
+                                     fileID: String = #fileID,
+                                     line: UInt = #line,
+                                     function: String = #function) {
         log(logLevel: LogLevel.info,
             message: message,
             fileID: fileID,
@@ -63,82 +58,58 @@ public class AirshipLogger : NSObject {
             skipLogLevelCheck: true)
     }
 
-    public static func warn(_ message: String,
+    public static func warn(_ message: @autoclosure () -> String,
                             fileID: String = #fileID,
-                            line: Int = #line,
+                            line: UInt = #line,
                             function: String = #function) {
         log(logLevel: LogLevel.warn,
-            message: message,
+            message: message(),
             fileID: fileID,
             line: line,
             function: function)
     }
 
-    public static func error(_ message: String,
+    public static func error(_ message: @autoclosure () -> String,
                              fileID: String = #fileID,
-                             line: Int = #line,
+                             line: UInt = #line,
                              function: String = #function) {
 
         log(logLevel: LogLevel.error,
-            message: message,
+            message: message(),
             fileID: fileID,
             line: line,
             function: function)
     }
 
-    public static func impError(_ message: String,
+    public static func impError(_ message: @autoclosure () -> String,
                                 fileID: String = #fileID,
-                                line: Int = #line,
+                                line: UInt = #line,
                                 function: String = #function) {
 
         log(logLevel: LogLevel.error,
-            message: "🚨Airship Implementation Error🚨: \(message)",
+            message: "🚨Airship Implementation Error🚨: \(message())",
             fileID: fileID,
             line: line,
             function: function)
     }
 
-    private static func log(logLevel: LogLevel,
-                            message: String,
-                            fileID: String,
-                            line: Int,
-                            function: String,
-                            skipLogLevelCheck: Bool = false) {
-        
-        guard self.logLevel != .none,
-              self.logLevel != .undefined else {
+    static func log(logLevel: LogLevel,
+                    message: @autoclosure () -> String,
+                    fileID: String,
+                    line: UInt,
+                    function: String,
+                    skipLogLevelCheck: Bool = false) {
+
+        guard self.logLevel != .none, self.logLevel != .undefined else {
             return
         }
 
         if (skipLogLevelCheck || self.logLevel.rawValue >= logLevel.rawValue) {
-            if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
-                LOGGER.log(level: logType(logLevel), "[\(logInitial(logLevel))] \(fileID) \(function) [Line \(line)] \(message)")
-            } else {
-                print("[\(logInitial(logLevel))] \(fileID) \(function) [Line \(line)] \(message)")
-            }
-        }
-    }
-
-    private static func logInitial(_ logLevel: LogLevel) -> String {
-        switch logLevel {
-        case .trace: return "T"
-        case .debug: return "D"
-        case .info: return "I"
-        case .warn: return "W"
-        case .error: return "E"
-        default: return ""
-        }
-    }
-
-    private static func logType(_ logLevel: LogLevel) -> OSLogType {
-        switch logLevel {
-        case .trace: return OSLogType.debug
-        case .debug: return OSLogType.debug
-        case .info: return OSLogType.info
-        case .warn: return OSLogType.info
-        case .error: return OSLogType.error
-        default: return OSLogType.default
+            logHandler.log(logLevel: logLevel,
+                           message: message(),
+                           fileID: fileID,
+                           line: line,
+                           function: function)
         }
     }
 }
-

--- a/Airship/AirshipCore/Source/DefaultLogHandler.swift
+++ b/Airship/AirshipCore/Source/DefaultLogHandler.swift
@@ -8,7 +8,7 @@ import os
  */
 class DefaultLogHandler: AirshipLogHandler {
     @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
-    static var logger: Logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "", category: "Airship")
+    private static let logger: Logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "", category: "Airship")
 
     func log(logLevel: LogLevel, message: String, fileID: String, line: UInt, function: String) {
         if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
@@ -36,7 +36,7 @@ private extension LogLevel {
         case .trace: return OSLogType.debug
         case .debug: return OSLogType.debug
         case .info: return OSLogType.info
-        case .warn: return OSLogType.info
+        case .warn: return OSLogType.default
         case .error: return OSLogType.error
         default: return OSLogType.default
         }

--- a/Airship/AirshipCore/Source/DefaultLogHandler.swift
+++ b/Airship/AirshipCore/Source/DefaultLogHandler.swift
@@ -1,0 +1,44 @@
+/* Copyright Airship and Contributors */
+
+import Foundation
+import os
+
+/**
+ * Default log handler. Logs to either os.Logger or just prints depending on OS version.
+ */
+class DefaultLogHandler: AirshipLogHandler {
+    @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+    static var logger: Logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "", category: "Airship")
+
+    func log(logLevel: LogLevel, message: String, fileID: String, line: UInt, function: String) {
+        if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+            DefaultLogHandler.logger.log(level: logLevel.logType, "[\(logLevel.initial)] \(fileID) \(function) [Line \(line)] \(message)")
+        } else {
+            print("[\(logLevel.initial)] \(fileID) \(function) [Line \(line)] \(message)")
+        }
+    }
+}
+
+private extension LogLevel {
+    var initial: String {
+        switch self {
+        case .trace: return "T"
+        case .debug: return "D"
+        case .info: return "I"
+        case .warn: return "W"
+        case .error: return "E"
+        default: return "U"
+        }
+    }
+
+    var logType: OSLogType {
+        switch self {
+        case .trace: return OSLogType.debug
+        case .debug: return OSLogType.debug
+        case .info: return OSLogType.info
+        case .warn: return OSLogType.info
+        case .error: return OSLogType.error
+        default: return OSLogType.default
+        }
+    }
+}

--- a/Airship/AirshipLocation/Source/UALocation.m
+++ b/Airship/AirshipLocation/Source/UALocation.m
@@ -207,7 +207,7 @@ NSString *const UALocationUpdatesEnabled = @"UALocationUpdatesEnabled";
 #if !TARGET_OS_TV   // significantLocationChangeMonitoringAvailable not available on tvOS
     // Check if significant location updates are available
     if (![CLLocationManager significantLocationChangeMonitoringAvailable]) {
-        UA_LTRACE("Significant location updates unavailable.");
+        UA_LTRACE(@"Significant location updates unavailable.");
         [self stopLocationUpdates];
         return;
     }
@@ -223,7 +223,7 @@ NSString *const UALocationUpdatesEnabled = @"UALocationUpdatesEnabled";
     switch ([CLLocationManager authorizationStatus]) {
         case kCLAuthorizationStatusDenied:
         case kCLAuthorizationStatusRestricted:
-            UA_LTRACE("Authorization denied. Unable to start location updates.");
+            UA_LTRACE(@"Authorization denied. Unable to start location updates.");
             [self stopLocationUpdates];
             break;
 
@@ -245,7 +245,7 @@ NSString *const UALocationUpdatesEnabled = @"UALocationUpdatesEnabled";
         return;
     }
 
-    UA_LINFO("Stopping location updates.");
+    UA_LINFO(@"Stopping location updates.");
 
 #if !TARGET_OS_TV   // REVISIT - significant location updates not available on tvOS - should we use regular location updates?
     [self.locationManager stopMonitoringSignificantLocationChanges];
@@ -268,7 +268,7 @@ NSString *const UALocationUpdatesEnabled = @"UALocationUpdatesEnabled";
         return;
     }
 
-    UA_LINFO("Starting location updates.");
+    UA_LINFO(@"Starting location updates.");
 
 #if !TARGET_OS_TV   // REVISIT - significant location updates not available on tvOS - should we use regular location updates?
     [self.locationManager startMonitoringSignificantLocationChanges];
@@ -288,12 +288,12 @@ NSString *const UALocationUpdatesEnabled = @"UALocationUpdatesEnabled";
     }
 
     if (!self.isAutoRequestAuthorizationEnabled) {
-        UA_LINFO("Location updates require authorization, auto request authorization is disabled. You must manually request location authorization.");
+        UA_LINFO(@"Location updates require authorization, auto request authorization is disabled. You must manually request location authorization.");
         return;
     }
 
     if ([UIApplication sharedApplication].applicationState != UIApplicationStateActive) {
-        UA_LINFO("Location updates require authorization, but app is not active. Authorization will be requested next time the app is active.");
+        UA_LINFO(@"Location updates require authorization, but app is not active. Authorization will be requested next time the app is active.");
         return;
     }
 
@@ -301,7 +301,7 @@ NSString *const UALocationUpdatesEnabled = @"UALocationUpdatesEnabled";
         return;
     }
 
-    UA_LINFO("Requesting location authorization.");
+    UA_LINFO(@"Requesting location authorization.");
 #if TARGET_OS_TV //requestAlwaysAuthorization is not available on tvOS
     [self.locationManager requestWhenInUseAuthorization];
 #else

--- a/Airship/AirshipMessageCenter/Source/UAMessageCenter.m
+++ b/Airship/AirshipMessageCenter/Source/UAMessageCenter.m
@@ -50,6 +50,8 @@ NSString *const UAMessageDataScheme = @"message";
         self.privacyManager = privacyManager;
         self.disableHelper = [[UAComponentDisableHelper alloc] initWithDataStore:dataStore
                                                                        className:@"UAMessageCenter"];
+
+
         
         [self updateEnableState];
         


### PR DESCRIPTION
### What do these changes do?
This PR does a few things:
- Makes it so apps can override how Airship logs
- Improves filtering by using autoclosure blocks to prevent computing the message
- Bridge all objective-c logs to AirshipLogger so we no longer use NSLog.


### How did you verify these changes?
Ran sample app, verified logs are coming through still.

