### PR TITLE
Store the correct UUID to the keychain

### DIFF
--- a/Airship/AirshipCore/Source/PreferenceDataStore.swift
+++ b/Airship/AirshipCore/Source/PreferenceDataStore.swift
@@ -300,7 +300,7 @@ extension AirshipKeychainAccess {
         self.writeCredentials(
             AirshipKeychainCredentials(
                 username: "airship",
-                password: UUID().uuidString
+                password: newDeviceID
             ),
             identifier: "com.urbanairship.deviceID"
         ) { result in


### PR DESCRIPTION
### What do these changes do?

It fixes a bug where the device ID stored in the keychain on first use is not the one returned to that caller. 

### Why are these changes necessary?

Seems pretty important the device ID used during the first run is identical with the one later. 

### How did you verify these changes?

👀 

### Anything else a reviewer should know?

Maybe this method should get a unit test? 
