### PR TITLE
Stop using instance based encoder

### DIFF
--- a/Airship/AirshipCore/Source/ChannelAPIClient.swift
+++ b/Airship/AirshipCore/Source/ChannelAPIClient.swift
@@ -6,7 +6,6 @@ final class ChannelAPIClient: ChannelAPIClientProtocol, Sendable {
 
     private let config: RuntimeConfig
     private let session: AirshipRequestSession
-    private let encoder: JSONEncoder = JSONEncoder()
 
     init(
         config: RuntimeConfig,
@@ -46,7 +45,7 @@ final class ChannelAPIClient: ChannelAPIClientProtocol, Sendable {
         payload: ChannelRegistrationPayload
     ) async throws -> AirshipHTTPResponse<ChannelAPIResponse> {
         let url = try makeURL(path: self.channelPath)
-        let data = try encoder.encode(payload)
+        let data = try JSONEncoder().encode(payload)
 
         AirshipLogger.debug(
             "Creating channel with: \(payload)"
@@ -100,7 +99,7 @@ final class ChannelAPIClient: ChannelAPIClientProtocol, Sendable {
     ) async throws -> AirshipHTTPResponse<ChannelAPIResponse> {
 
         let url = try makeChannelLocation(channelID: channelID)
-        let data = try encoder.encode(payload)
+        let data = try JSONEncoder().encode(payload)
 
         AirshipLogger.debug(
             "Updating channel \(channelID) with: \(payload)"


### PR DESCRIPTION
<!--

Please fill out this template when submitting an pull request.

All lines beginning with an ℹ symbol indicate information that's
important for you to provide to ensure your pull request is reviewed
as quickly and efficiently as possible.

-->

### What do these changes do?
The changes removes the usage of an instance base encoder and generates a new one for each request under the `ChannelAPIClient`

### Why are these changes necessary?
<!-- ℹ Please provide a concise description of why your changes are
necessary here. -->

While its not documented very well, JSONEncoder/Decoder are a stateful objects, which makes them non-thread safe.
We are using version `17.10.0` and facing exceptions around that code, which made me think its a thread issue.
In anyway spinning a new encoder/decoder is the recommended way and very cheap in resources.

### How did you verify these changes?
<!-- ℹ Please provide any relevant steps to verify or test your work. Make
this description clear enough so someone unfamiliar with your work could
verify for you. -->

Testing for thread safety issues is a hard task, as such I could not create a test to reproduce it.
Here is a thread supporting my theory - https://forums.swift.org/t/is-it-ok-to-create-jsondecoder-only-once-in-withthrowingtaskgroup/57260

#### Verification Screenshots:
<!-- ℹ If applicable, please provide screenshots here. -->

### Anything else a reviewer should know?
<!-- ℹ Please provide any additional notes for the reviewer here. -->

Here is the stack trace at the app level crash
```
Crashed in non-app Foundation | +0x04e7b0 | String.withUTF8<T>
Foundation | +0x04e798 | String.withUTF8<T>
Foundation | +0x04eb88 | JSONWriter.serializeString
Foundation | +0x04e80c | JSONWriter.serializeJSON
Foundation | +0x04cfd0 | JSONWriter.serializeObject
Foundation | +0x04e910 | JSONWriter.serializeJSON
Foundation | +0x04cfd0 | JSONWriter.serializeObject
Foundation | +0x04e910 | JSONWriter.serializeJSON
Foundation | +0x0d06f8 | JSONEncoder.encode<T>
Foundation | +0x0d0480 | JSONEncoder.encode<T>
MyAppName | +0xf8a454 | ChannelAPIClient.updateChannel (ChannelAPIClient.swift:105) (In App)
Called from libswift_Concurrency | +0x04d760 | swift::runJobInEstablishedExecutorContext
```

