### PR TITLE
Remove AirshipPush.authorizedNotificationSettings MainActor isolation

### DIFF
--- a/Airship/AirshipCore/Source/Push.swift
+++ b/Airship/AirshipCore/Source/Push.swift
@@ -460,7 +460,6 @@ final class AirshipPush: NSObject, AirshipPushProtocol, @unchecked Sendable {
     #endif
 
     @objc
-    @MainActor
     public private(set) var authorizedNotificationSettings: UAAuthorizedNotificationSettings {
         set {
             self.dataStore.setInteger(

--- a/Airship/AirshipCore/Tests/PushTest.swift
+++ b/Airship/AirshipCore/Tests/PushTest.swift
@@ -648,7 +648,6 @@ class PushTest: XCTestCase {
         XCTAssertEqual(0, self.badger.applicationIconBadgeNumber)
     }
 
-    @MainActor
     func testActiveChecksRegistration() async  {
         self.notificationRegistrar.onCheckStatus = {
             return (.authorized, [.alert])


### PR DESCRIPTION
### What do these changes do?
Removes unnecessary MainActor isolation of the `AirshipPush.authorizedNotificationSettings` property.  Based on the implementation of `AirshipPush.authorizedNotificationSettings` there is nothing that should force the property to be MainActor isolated since it only reads and writes to the `AirshipPush` `PreferenceDataStore` that uses its own `NSRecursiveLock` for synchronization.  There are `AirshipPush` properties like `authorizationStatus` and `userPromptedForNotifications` that read and write to the `AirshipPush` `PreferenceDataStore` without requiring MainActor isolation.  These changes will not affect any users who are currently using `AirshipPush.authorizedNotificationSettings` in a MainActor isolated context.

### Why are these changes necessary?
We should prefer to only use MainActor isolation unless it is absolutely necessary.

### How did you verify these changes?
The SDK builds and all test cases pass.

