### PR TITLE
Remove Stateful JSON encoding and decoding

### DIFF
--- a/Airship/AirshipCore/Source/ChannelAudienceManager.swift
+++ b/Airship/AirshipCore/Source/ChannelAudienceManager.swift
@@ -45,8 +45,6 @@ final class ChannelAudienceManager: ChannelAudienceManagerProtocol {
     private let audienceOverridesProvider: AudienceOverridesProvider
 
     private let date: AirshipDateProtocol
-    private let encoder = JSONEncoder()
-    private let decoder = JSONDecoder()
     private let updateLock = AirshipLock()
 
     private let cachedSubscriptionLists: CachedValue<[String]>
@@ -409,7 +407,7 @@ final class ChannelAudienceManager: ChannelAudienceManagerProtocol {
             if let data = self.dataStore.data(
                 forKey: ChannelAudienceManager.updatesKey
             ) {
-                result = try? self.decoder.decode(
+                result = try? JSONDecoder().decode(
                     [AudienceUpdate].self,
                     from: data
                 )
@@ -420,7 +418,7 @@ final class ChannelAudienceManager: ChannelAudienceManagerProtocol {
 
     private func storeUpdates(_ operations: [AudienceUpdate]) {
         updateLock.sync {
-            if let data = try? self.encoder.encode(operations) {
+            if let data = try? JSONEncoder().encode(operations) {
                 self.dataStore.setObject(
                     data,
                     forKey: ChannelAudienceManager.updatesKey

--- a/Airship/AirshipCore/Source/ChannelAuthTokenAPIClient.swift
+++ b/Airship/AirshipCore/Source/ChannelAuthTokenAPIClient.swift
@@ -4,7 +4,6 @@ final class ChannelAuthTokenAPIClient: ChannelAuthTokenAPIClientProtocol, Sendab
     private let tokenPath = "/api/auth/device"
     private let config: RuntimeConfig
     private let session: AirshipRequestSession
-    private let decoder: JSONDecoder = JSONDecoder()
 
     init(
         config: RuntimeConfig,

--- a/Airship/AirshipCore/Source/ContactAPIClient.swift
+++ b/Airship/AirshipCore/Source/ContactAPIClient.swift
@@ -72,7 +72,7 @@ final class ContactAPIClient: ContactsAPIClientProtocol {
     private let config: RuntimeConfig
     private let session: AirshipRequestSession
 
-    private let decoder: JSONDecoder = {
+    private var decoder: JSONDecoder {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .custom({ (decoder) -> Date in
             let container = try decoder.singleValueContainer()
@@ -84,9 +84,9 @@ final class ContactAPIClient: ContactsAPIClientProtocol {
             return date
         })
         return decoder
-    }()
+    }
 
-    private let encoder: JSONEncoder = {
+    private var encoder: JSONEncoder {
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .custom({ date, encoder in
             var container = encoder.singleValueContainer()
@@ -95,7 +95,7 @@ final class ContactAPIClient: ContactsAPIClientProtocol {
             )
         })
         return encoder
-    }()
+    }
 
     init(config: RuntimeConfig, session: AirshipRequestSession) {
         self.config = config

--- a/Airship/AirshipCore/Source/ContactChannelsAPIClient.swift
+++ b/Airship/AirshipCore/Source/ContactChannelsAPIClient.swift
@@ -14,7 +14,7 @@ final class ContactChannelsAPIClient: ContactChannelsAPIClientProtocol {
     private let config: RuntimeConfig
     private let session: AirshipRequestSession
     
-    private let decoder: JSONDecoder = {
+    private var decoder: JSONDecoder {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .custom({ (decoder) -> Date in
             let container = try decoder.singleValueContainer()
@@ -26,7 +26,7 @@ final class ContactChannelsAPIClient: ContactChannelsAPIClientProtocol {
             return date
         })
         return decoder
-    }()
+    }
     
     init(config: RuntimeConfig, session: AirshipRequestSession) {
         self.config = config

--- a/Airship/AirshipCore/Source/PreferenceDataStore.swift
+++ b/Airship/AirshipCore/Source/PreferenceDataStore.swift
@@ -8,9 +8,6 @@ public final class PreferenceDataStore: @unchecked Sendable {
     private let defaults: UserDefaults
     private let appKey: String
     static let deviceIDKey = "deviceID"
-
-    private let decoder = JSONDecoder()
-    private let encoder = JSONEncoder()
     
     private var pending: [String: [Any?]] = [:]
     private var cache: [String: Cached] = [:]
@@ -177,7 +174,7 @@ public final class PreferenceDataStore: @unchecked Sendable {
             return nil
         }
 
-        return try decoder.decode(T.self, from: data)
+        return try JSONDecoder().decode(T.self, from: data)
     }
 
     public func safeCodable<T: Codable>(forKey key: String) -> T? {
@@ -209,7 +206,7 @@ public final class PreferenceDataStore: @unchecked Sendable {
             return
         }
 
-        let data = try encoder.encode(codable)
+        let data = try JSONEncoder().encode(codable)
         write(key, value: data)
     }
 

--- a/Airship/AirshipCore/Source/RemoteDataAPIClient.swift
+++ b/Airship/AirshipCore/Source/RemoteDataAPIClient.swift
@@ -13,7 +13,7 @@ final class RemoteDataAPIClient: RemoteDataAPIClientProtocol {
     private let session: AirshipRequestSession
     private let config: RuntimeConfig
 
-    private let decoder: JSONDecoder = {
+    private var decoder: JSONDecoder {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .custom({ (decoder) -> Date in
             let container = try decoder.singleValueContainer()
@@ -25,7 +25,7 @@ final class RemoteDataAPIClient: RemoteDataAPIClientProtocol {
             return date
         })
         return decoder
-    }()
+    }
 
     init(config: RuntimeConfig, session: AirshipRequestSession) {
         self.config = config

--- a/Airship/AirshipCore/Source/RemoteDataInfo.swift
+++ b/Airship/AirshipCore/Source/RemoteDataInfo.swift
@@ -14,14 +14,11 @@ public struct RemoteDataInfo: Sendable, Codable, Equatable, Hashable {
         self.contactID = contactID
     }
 
-    private static let decoder = JSONDecoder()
-    private static let encoder = JSONEncoder()
-
     static func fromJSON(data: Data) throws -> RemoteDataInfo {
-        return try RemoteDataInfo.decoder.decode(RemoteDataInfo.self, from: data)
+        try JSONDecoder().decode(RemoteDataInfo.self, from: data)
     }
 
     func toEncodedJSONData() throws -> Data {
-        return try RemoteDataInfo.encoder.encode(self)
+        try JSONEncoder().encode(self)
     }
 }

--- a/Airship/AirshipCore/Source/SMSValidator.swift
+++ b/Airship/AirshipCore/Source/SMSValidator.swift
@@ -92,7 +92,7 @@ final class SMSValidatorAPIClient: SMSValidatorAPIClientProtocol {
     private let config: RuntimeConfig
     private let session: AirshipRequestSession
 
-    private let decoder: JSONDecoder = {
+    private var decoder: JSONDecoder {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .custom({ (decoder) -> Date in
             let container = try decoder.singleValueContainer()
@@ -104,9 +104,9 @@ final class SMSValidatorAPIClient: SMSValidatorAPIClientProtocol {
             return date
         })
         return decoder
-    }()
+    }
 
-    private let encoder: JSONEncoder = {
+    private var encoder: JSONEncoder = {
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .custom({ date, encoder in
             var container = encoder.singleValueContainer()

--- a/Airship/AirshipCore/Source/SubscriptionListAction.swift
+++ b/Airship/AirshipCore/Source/SubscriptionListAction.swift
@@ -23,11 +23,11 @@ public final class SubscriptionListAction: AirshipAction {
     private let channel: @Sendable () -> AirshipChannelProtocol
     private let contact: @Sendable () -> AirshipContactProtocol
   
-    private let decoder: JSONDecoder = {
+    private var decoder: JSONDecoder {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
         return decoder
-    }()
+    }
     
     public var _decoder: JSONDecoder {
         return decoder


### PR DESCRIPTION
<!--

Please fill out this template when submitting an pull request.

All lines beginning with an ℹ symbol indicate information that's
important for you to provide to ensure your pull request is reviewed
as quickly and efficiently as possible.

-->

This PR is in response to [this one](https://github.com/urbanairship/ios-library/pull/408), converting all instance based usage of encoders/decoder

### What do these changes do?
<!-- ℹ Please provide a description of your changes here. -->

The changes removes the usage of an instance base encoders/decoders

### Why are these changes necessary?
<!-- ℹ Please provide a concise description of why your changes are
necessary here. -->

While its not documented very well, JSONEncoder/Decoder are a stateful objects, which makes them non-thread safe.
We are using version 17.10.0 and facing exceptions around that code, which made me think its a thread issue.
In anyway spinning a new encoder/decoder is the recommended way and very cheap in resources.

### How did you verify these changes?
<!-- ℹ Please provide any relevant steps to verify or test your work. Make
this description clear enough so someone unfamiliar with your work could
verify for you. -->

Testing for thread safety issues is a hard task, as such I could not create a test to reproduce it.
Here is a thread supporting my theory - https://forums.swift.org/t/is-it-ok-to-create-jsondecoder-only-once-in-withthrowingtaskgroup/57260

#### Verification Screenshots:
<!-- ℹ If applicable, please provide screenshots here. -->

### Anything else a reviewer should know?
<!-- ℹ Please provide any additional notes for the reviewer here. -->

Here is the stack trace at the app level crash

Crashed in non-app Foundation | +0x04e7b0 | String.withUTF8<T>
Foundation | +0x04e798 | String.withUTF8<T>
Foundation | +0x04eb88 | JSONWriter.serializeString
Foundation | +0x04e80c | JSONWriter.serializeJSON
Foundation | +0x04cfd0 | JSONWriter.serializeObject
Foundation | +0x04e910 | JSONWriter.serializeJSON
Foundation | +0x04cfd0 | JSONWriter.serializeObject
Foundation | +0x04e910 | JSONWriter.serializeJSON
Foundation | +0x0d06f8 | JSONEncoder.encode<T>
Foundation | +0x0d0480 | JSONEncoder.encode<T>
MyAppName | +0xf8a454 | ChannelAPIClient.updateChannel (ChannelAPIClient.swift:105) (In App)
Called from libswift_Concurrency | +0x04d760 | swift::runJobInEstablishedExecutorContext
