### PR TITLE
Refactor nextAvailable to use max(by:) for delays

### DIFF
--- a/Airship/AirshipCore/Source/WorkRateLimiterActor.swift
+++ b/Airship/AirshipCore/Source/WorkRateLimiterActor.swift
@@ -33,14 +33,20 @@ actor WorkRateLimiter {
     }
 
     func nextAvailable(_ keys: [String]) -> TimeInterval {
-        return
-            keys.map { key in
-                guard case .overLimit(let delay) = status(key) else {
-                    return 0.0
-                }
-                return delay
+        
+        func maxDelay(between a: String, b: String) -> Bool {
+            let statusA = self.status(a)
+            let statusB = self.status(b)
+            if case .overLimit(let delayA) = statusA, case .overLimit(let delayB) = statusB {
+                return delayA > delayB
             }
-            .max() ?? 0.0
+            return false
+        }
+
+        guard let maxKey = keys.max(by: { maxDelay(between: $0, b: $1) }), case .overLimit(let delay) = self.status(maxKey) else {
+            return 0.0
+        }
+        return delay
     }
 
     func trackIfWithinLimit(_ keys: [String]) -> Bool {


### PR DESCRIPTION
Refactor nextAvailable method to include max(by:) function for better delay calculation.
This is a memory optimization instead of creating a new array and max it.

<!--

Please fill out this template when submitting an pull request.

All lines beginning with an ℹ symbol indicate information that's
important for you to provide to ensure your pull request is reviewed
as quickly and efficiently as possible.

-->

### What do these changes do?
Refactor nextAvailable method to include max(by:) function for better delay calculation.
This is a memory optimization instead of creating a new array and max it.

### Why are these changes necessary?
We have seen memory exceptions in our app (which has high memory consumption to begin with).
Where the OS runtime cannot assign more memory for the new array that is derived from the `map` operation
```sh
EXC_BREAKPOINT
Could not allocate memory.

Location | Address | Function
libswiftCore | +0x046b568 | swift::hashable_support::findHashableBaseType
App | +0x17ee3f4 | _ArrayBuffer._consumeAndCreateNew
App | +0x17ed044 | ContiguousArray._createNewBuffer ()
App | +0x1beecac | ContiguousArray._reserveCapacityImpl ()
App | +0x1beecac | ContiguousArray.reserveCapacity ()
App | +0x1beecac | Collection.map ()
App | +0x1beb0f0 | Collection.map ()
App | +0x1beb0f0 | WorkRateLimiter.nextAvailable (WorkRateLimiterActor.swift:37)
App | +0x1beb0f0 | Worker.calculateBackgroundWaitTime (Worker.swift:203)
Called from |   |  
libswift_Concurrency | +0x005c130 | swift::runJobInEstablishedExecutorContext

```

### How did you verify these changes?
It was hard to reproduce in a unittest because mac has much higher memory consumption. So I dind't validate the change actually solves the crash.
Having said that, it is clearly and optimization of the process with the same outcome
