### PR TITLE
Fix: use Bundle.module for SwiftPM resources

### DIFF
--- a/Airship/AirshipCore/Source/AirshipCoreResources.swift
+++ b/Airship/AirshipCore/Source/AirshipCoreResources.swift
@@ -9,6 +9,9 @@ public final class AirshipCoreResources {
     public static let bundle = findBundle()
 
     private class func findBundle() -> Bundle {
+#if SWIFT_PACKAGE
+        return Bundle.module
+#else
         let mainBundle = Bundle.main
         let sourceBundle = Bundle(for: AirshipCoreResources.self)
 
@@ -44,5 +47,6 @@ public final class AirshipCoreResources {
 
         // Fallback to source
         return sourceBundle
+#endif
     }
 }


### PR DESCRIPTION
## Summary
Return `Bundle.module` when building as a SwiftPM package to avoid relying on bundle path assumptions.

## Context
Fixes the resource lookup crash described in #444 by using the synthesized SwiftPM bundle.
