### PR TITLE
Fix visionOS compilation with proper availability checks

### DIFF
--- a/Airship/AirshipCore/Source/Icons.swift
+++ b/Airship/AirshipCore/Source/Icons.swift
@@ -148,7 +148,7 @@ private struct ProgressSpinnerIconView: View {
     let color: Color
     
     var body: some View {
-        if #available(iOS 18.0, *) {
+        if #available(iOS 18.0, visionOS 2.0, *) {
             makeSystemImageIcon(
                 name: "progress.indicator",
                 resizable: resizable,

--- a/Airship/AirshipCore/Source/Label.swift
+++ b/Airship/AirshipCore/Source/Label.swift
@@ -84,7 +84,7 @@ struct Label: View {
                     .accessibilityHidden(true)
             }
 
-            if #available(iOS 26.0, *) {
+            if #available(iOS 26.0, visionOS 26.0, *) {
                 self.textView
                     .textAppearance(resolvedTextAppearance, colorScheme: colorScheme)
                     .truncationMode(.tail)
@@ -343,7 +343,7 @@ extension Label {
 
                 if seg.isHighlight {
                     // For custom cornerRadius we have to use a custom attribute and renderer
-                    if #available(iOS 18.0, *), let cornerRadius = highlightOptions?.cornerRadius {
+                    if #available(iOS 18.0, visionOS 2.0, *), let cornerRadius = highlightOptions?.cornerRadius {
                         let highlight = HighlightAttribute(
                             color: highlightOptions?.color?.toColor(colorScheme) ?? Self.defaultHighlightColor,
                             cornerRadius: cornerRadius


### PR DESCRIPTION
### What do these changes do?
Fixes package compilation on visionOS with proper availability checks analogous to the iOS checks in `ProgressSpinnerIconView` and `Label` views in AirshipCore.

### Why are these changes necessary?
Currently the package does not compile on visionOS (e.g. in version 20.3.1)

### How did you verify these changes?
Checked out the branch and built with current Xcode 26.3 RC and Xcode 26.4 B1.
